### PR TITLE
Change Behaviour of Constructor Comparison

### DIFF
--- a/haskell-src-transformations.cabal
+++ b/haskell-src-transformations.cabal
@@ -62,7 +62,9 @@ test-suite haskell-src-transformations-unit-tests
   hs-source-dirs:     src/test
   main-is:            Spec.hs
   ghc-options:        -main-is Spec
-  -- other-modules: TODO add unit tests
+  other-modules:      AlgoTests
   build-depends:      base
+                    , haskell-src-transformations
+                    , HUnit
                     , hspec
                     , QuickCheck

--- a/src/lib/Algo.hs
+++ b/src/lib/Algo.hs
@@ -11,6 +11,8 @@ module Algo
   , Eqs
   , isPVar
   , isCons
+  -- * Testing interface.
+  , compareCons
   )
 where
 

--- a/src/lib/Algo.hs
+++ b/src/lib/Algo.hs
@@ -293,7 +293,9 @@ compareCons (PApp _ qn1 _       ) (PInfixApp _ _ qn2 _) = qn1 == qn2
 compareCons (PInfixApp _ _ qn1 _) (PApp _ qn2 _       ) = qn1 == qn2
 compareCons (PParen _ p1        ) p2                    = compareCons p1 p2
 compareCons p1                    (PParen _ p2)         = compareCons p1 p2
--- Lists have the same constructor if both are empty or both are non empty
+compareCons (PWildCard _) (PWildCard _)                 = True
+
+-- Lists have the same constructor if both are empty or both are non-empty.
 compareCons (PList _ []) (PList _ [])                   = True
 compareCons (PList _ (_ : _)) (PList _ (_ : _))         = True
 compareCons (PList _ (_ : _)) (PApp _ (Special () (Cons ())) _) = True
@@ -301,9 +303,14 @@ compareCons (PApp _ (Special () (Cons ())) _) (PList _ (_ : _)) = True
 compareCons (PList _ (_ : _)) (PInfixApp _ _ (Special () (Cons ())) _) = True
 compareCons (PInfixApp _ _ (Special () (Cons ())) _) (PList _ (_ : _)) = True
 
-compareCons (PWildCard _) (PWildCard _)                 = True
+-- Tuple constructers match if both have the same number of elements.
 compareCons (PTuple _ _ ps1) (PTuple _ _ ps2) = length ps1 == length ps2
-compareCons _                     _                     = False
+compareCons (PTuple _ _ ps) (PApp _ (Special () (TupleCon () Boxed arity)) _) =
+  length ps == arity
+compareCons (PApp _ (Special () (TupleCon () Boxed arity)) _) (PTuple _ _ ps) =
+  length ps == arity
+
+compareCons _ _ = False
 
 -- | Creates an alternative for a @case@ expression for the given group of
 --   equations whose first pattern matches the same constructor.

--- a/src/lib/Algo.hs
+++ b/src/lib/Algo.hs
@@ -300,7 +300,7 @@ consName (PInfixApp _ _ qn _) = return qn
 consName (PParen _ pat      ) = consName pat
 consName (PList  _ []       ) = return $ Special () $ ListCon ()
 consName (PList  _ (_ : _)  ) = return $ Special () $ Cons ()
-consName (PTuple _ _ ps) = return $ Special () $ TupleCon () Boxed $ length ps
+consName (PTuple _ bxd ps) = return $ Special () $ TupleCon () bxd $ length ps
 consName (PWildCard _       ) = Nothing
 consName pat =
   error $ "consName: unsupported pattern \"" ++ prettyPrint pat ++ "\""

--- a/src/lib/Algo.hs
+++ b/src/lib/Algo.hs
@@ -11,7 +11,7 @@ module Algo
   , Eqs
   , isPVar
   , isCons
-  -- * Testing interface.
+  -- * Testing interface
   , compareCons
   )
 where

--- a/src/lib/Algo.hs
+++ b/src/lib/Algo.hs
@@ -292,10 +292,16 @@ compareCons (PInfixApp _ _ qn1 _) (PInfixApp _ _ qn2 _) = qn1 == qn2
 compareCons (PApp _ qn1 _       ) (PInfixApp _ _ qn2 _) = qn1 == qn2
 compareCons (PInfixApp _ _ qn1 _) (PApp _ qn2 _       ) = qn1 == qn2
 compareCons (PParen _ p1        ) p2                    = compareCons p1 p2
-compareCons p1                    (PParen _ p2   )      = compareCons p1 p2
--- TODO Special Syntax
-compareCons (PList _ ps1) (PList _ ps2) = length ps1 == length ps2
-compareCons (PWildCard _   )      (PWildCard _   )      = True
+compareCons p1                    (PParen _ p2)         = compareCons p1 p2
+-- Lists have the same constructor if both are empty or both are non empty
+compareCons (PList _ []) (PList _ [])                   = True
+compareCons (PList _ (_ : _)) (PList _ (_ : _))         = True
+compareCons (PList _ (_ : _)) (PApp _ (Special () (Cons ())) _) = True
+compareCons (PApp _ (Special () (Cons ())) _) (PList _ (_ : _)) = True
+compareCons (PList _ (_ : _)) (PInfixApp _ _ (Special () (Cons ())) _) = True
+compareCons (PInfixApp _ _ (Special () (Cons ())) _) (PList _ (_ : _)) = True
+
+compareCons (PWildCard _) (PWildCard _)                 = True
 compareCons (PTuple _ _ ps1) (PTuple _ _ ps2) = length ps1 == length ps2
 compareCons _                     _                     = False
 

--- a/src/test/AlgoTests.hs
+++ b/src/test/AlgoTests.hs
@@ -7,7 +7,7 @@ import           Test.HUnit.Base                ( assertFailure )
 
 import           Algo
 
--- | Test group for 'Algo' tests.
+-- | Tests for the "Algo" module.
 testAlgo :: Spec
 testAlgo = context "Algo" testCompareCons
 

--- a/src/test/AlgoTests.hs
+++ b/src/test/AlgoTests.hs
@@ -9,7 +9,7 @@ import           Algo
 
 -- | Tests for the "Algo" module.
 testAlgo :: Spec
-testAlgo = context "Algo" testCompareCons
+testAlgo = describe "Algo" testCompareCons
 
 -- | Parse a pattern from the given string and sets the expectation that
 --   parsing is successful.
@@ -48,7 +48,7 @@ shouldNotMatchCons pat1 pat2
 
 -- | Test group for 'compareCons' tests.
 testCompareCons :: Spec
-testCompareCons = describe "matching constructors of patterns" $ do
+testCompareCons = context "matching constructors of patterns" $ do
   it "should match constructors in list notation and infix list constructor"
     $ do
         pat1 <- parseTestPat "[x]"

--- a/src/test/AlgoTests.hs
+++ b/src/test/AlgoTests.hs
@@ -1,0 +1,93 @@
+module AlgoTests where
+
+import           Control.Monad                  ( void )
+import           Language.Haskell.Exts
+import           Test.Hspec
+import           Test.HUnit.Base                ( assertFailure )
+
+import           Algo
+
+-- | Test group for 'Algo' tests.
+testAlgo :: Spec
+testAlgo = context "Algo" testCompareCons
+
+-- | Parse a pattern from the given string and sets the expectation that
+--   parsing is successful.
+parseTestPat :: String -> IO (Pat ())
+parseTestPat patStr = case parsePat patStr of
+  ParseOk pat          -> return $ void pat
+  ParseFailed _ errMsg -> assertFailure errMsg
+
+-- | Sets the expectation that the given patterns should have matching
+--   constructors.
+shouldMatchCons :: Pat () -> Pat () -> Expectation
+shouldMatchCons pat1 pat2
+  | compareCons pat1 pat2
+  = return ()
+  | otherwise
+  = assertFailure
+    $  "\""
+    ++ prettyPrint pat1
+    ++ "\" and \""
+    ++ prettyPrint pat2
+    ++ "\" should match the same constructor but they do not"
+
+-- | Sets the expectation that the given patterns should not have matching
+--   constructors.
+shouldNotMatchCons :: Pat () -> Pat () -> Expectation
+shouldNotMatchCons pat1 pat2
+  | compareCons pat1 pat2
+  = assertFailure
+    $  "\""
+    ++ prettyPrint pat1
+    ++ "\" and \""
+    ++ prettyPrint pat2
+    ++ "\" should not match the same constructor but they do"
+  | otherwise
+  = return ()
+
+-- | Test group for 'compareCons' tests.
+testCompareCons :: Spec
+testCompareCons = describe "matching constructors of patterns" $ do
+  it "should match constructors in list notation and infix list constructor"
+    $ do
+        pat1 <- parseTestPat "[x]"
+        pat2 <- parseTestPat "x : []"
+        pat1 `shouldMatchCons` pat2
+  it "should match constructors in list notation and prefix list constructor"
+    $ do
+        pat1 <- parseTestPat "[x]"
+        pat2 <- parseTestPat "(:) x []"
+        pat1 `shouldMatchCons` pat2
+  it "should match constructors infix and prefix list constructor" $ do
+    pat1 <- parseTestPat "x : []"
+    pat2 <- parseTestPat "(:) x []"
+    pat1 `shouldMatchCons` pat2
+  it "should match constructors of non-empty lists with different lengths" $ do
+    pat1 <- parseTestPat "[x]"
+    pat2 <- parseTestPat "[x, y]"
+    pat1 `shouldMatchCons` pat2
+  it "should match constructors of two empty lists" $ do
+    pat1 <- parseTestPat "[]"
+    pat2 <- parseTestPat "[]"
+    pat1 `shouldMatchCons` pat2
+  it "should match constructors of tuple notation and pair constructor" $ do
+    pat1 <- parseTestPat "(x, y)"
+    pat2 <- parseTestPat "(,) x y"
+    pat1 `shouldMatchCons` pat2
+  it "should match constructors of tuple notation and triple constructor" $ do
+    pat1 <- parseTestPat "(x, y, z)"
+    pat2 <- parseTestPat "(,,) x y z"
+    pat1 `shouldMatchCons` pat2
+  it "should not match constructors on empty and non-empty lists" $ do
+    pat1 <- parseTestPat "[]"
+    pat2 <- parseTestPat "[x]"
+    pat1 `shouldNotMatchCons` pat2
+  it "should not match constructors on tuples of different lengths" $ do
+    pat1 <- parseTestPat "(x, y)"
+    pat2 <- parseTestPat "(x, y, z)"
+    pat1 `shouldNotMatchCons` pat2
+  it "should not match constructors with different names" $ do
+    pat1 <- parseTestPat "C"
+    pat2 <- parseTestPat "D"
+    pat1 `shouldNotMatchCons` pat2

--- a/src/test/Spec.hs
+++ b/src/test/Spec.hs
@@ -2,5 +2,7 @@ module Spec where
 
 import           Test.Hspec
 
+import           AlgoTests
+
 main :: IO ()
-main = hspec $ return ()
+main = hspec testAlgo


### PR DESCRIPTION
Currently the patterns `[x]` and `(x : [])` are considered to have two distinct constructors. This can lead to some unintended behaviour, such that a single constructor is matched more than once(#7).
Therefore change the comparison of constructors, such that the prefix and infix list constructor and the list notation are the same if the list is not empty. Closes #7.

The same is done for the tupel constructor. Now `(x, y)` and `(,) x y` are considered the same.