### PR TITLE
Add run script and update formatting scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ If you want to run the command line interface without installing the package on 
 cabal new-run exe:haskell-src-transformations -- [options...]
 ```
 
-The two dashes are needed to separate the arguments to pass to the pattern matching compiler from Cabal’s arguments.
+The two dashes are needed to separate the arguments to pass to the pattern matching compiler from Cabal's arguments.
 Alternatively, you can use the `./tool/run.sh` bash script.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ haskell-src-transformations --help
 
 ### Running without Installation
 
-If you want to run the command line interface without installing the package on your machine (e.g., for debugging purposes), execute the following command in the root directory of the project instead of the `haskell-src-transformations`.
+If you want to run the command line interface without installing the package on your machine (e.g., for debugging purposes), execute the following command in the root directory of the project instead of using the `haskell-src-transformations` executable.
 
 ```bash
 cabal new-run exe:haskell-src-transformations -- [options...]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# haskell-src-transformations
+# haskell-src-transformations
 
 <!-- Badges -->
 ![CI Pipeline](https://github.com/FreeProving/haskell-src-transformations/workflows/CI%20Pipeline/badge.svg)
@@ -13,12 +13,13 @@ This tool was implemented as part of a bachelor thesis (by Malte Clement at Kiel
 3. [Getting Started](#getting-started)
     1. [Required Software](#required-software)
     2. [Executable Installation](#executable-installation)
-    3. [Library Installation](#library-installation)
+    3. [Running without Installation](#running-without-installation)
+    4. [Library Installation](#library-installation)
 4. [Usage](#usage)
 5. [Get Involved](#get-involved)
 6. [License](#license)
 
-# Haskell to Haskell Transformation Tool
+## Haskell to Haskell Transformation Tool
 
 This is a tool to translate different language features of Haskell into simpler expressions.
 
@@ -56,17 +57,38 @@ The tool has been tested with the following software versions.
 
 ### Executable Installation
 
-In order to install the command line interface, navigate to the root directory of the project and run
+In order to install the command line interface, navigate to the root directory of the project and run the following command.
 
 ```bash
 cabal new-install exe:haskell-src-transformations
 ```
 
-You can also run the executable directly without installing it first.
+The command above builds the executable pattern matching compiler's command line interface and creates a symbolic link in `~/.cabal/bin`.
+To test whether the installation was successful, make sure the `~/.cabal/bin` is in your `PATH` environment variable and run the following command.
+
+```
+haskell-src-transformations --help
+```
+
+### Running without Installation
+
+If you want to run the command line interface without installing the package on your machine (e.g., for debugging purposes), execute the following command in the root directory of the project instead of the `haskell-src-transformations`.
 
 ```bash
 cabal new-run exe:haskell-src-transformations -- [options...]
 ```
+
+The two dashes are needed to separate the arguments to pass to the pattern matching compiler from Cabal’s arguments.
+Alternatively, you can use the `./tool/run.sh` bash script.
+
+```bash
+./tool/run.sh [options...]
+```
+
+In addition to running the Cabal `new-run` command, the script also sets the `-Wwarn` flag of the GHC automatically.
+This flag ensures that warnings are not reported as errors by GHC which is convenient during development.
+In production, there should be no compiler warnings.
+Thus, the CI pipeline does not use the `./tool/run.sh` script but tests the compiler with the `-Werror` flag set.
 
 ### Library Installation
 

--- a/tool/check-formatting.sh
+++ b/tool/check-formatting.sh
@@ -36,24 +36,66 @@ if [ "${#files[@]}" == "0" ]; then
   files=(src example)
 fi
 
-# Format all given Haskell files that are tracked by `git` using `brittany`
-# and compare the output with the original file. Count the number of files
-# that need formatting.
-counter=0
+# Check all given Haskell files that are tracked by `git` and count the number
+# of files that are not formatted or encoded correctly.
+format_counter=0
+line_ending_counter=0
 for file in $(find "${files[@]}" -name '*.hs' -type f); do
-  if git ls-files --error-unmatch "$file" >/dev/null 2>&1; then
+  # Skip files that are not tracked by git.
+  if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1 ||
+       git ls-files --error-unmatch "$file" >/dev/null 2>&1; then
     echo -n "Checking ${bold}$file${reset} ... "
-    if brittany "$file" | cmp -s "$file"; then
+    is_okay=0
+
+    # Test whether the file uses Windows line endings (CRLF) or mixed line
+    # endings instead of Unix line endings (LF) by deleting all carriage
+    # return (CR) characters and comparing the output to the original file.
+    if ! tr -d '\r' <"$file" | cmp -s "$file"; then
+      echo -n "${yellow}${bold}HAS WRONG LINE ENDINGS${reset}"
+      line_ending_counter=$(expr $line_ending_counter + 1)
+      is_okay=1
+    fi
+
+    # Test whether the file is formatted by formatting it and comparing the
+    # output to the original file.
+    if ! brittany "$file" | cmp -s "$file"; then
+      if [ "$is_okay" -ne "0" ]; then
+        echo -n " and "
+      fi
+      echo -n "${red}${bold}NEEDS FORMATTING${reset}"
+      format_counter=$(expr $format_counter + 1)
+      is_okay=1
+    fi
+
+    if [ "$is_okay" -eq "0" ]; then
       echo "${green}${bold}OK${reset}"
     else
-      echo "${red}${bold}NEEDS FORMATTING${reset}"
-      counter=$(expr $counter + 1)
+      echo ""
     fi
+  else
+    echo "Skipping ${bold}$file${reset} ... ${bold}NOT TRACKED${reset}"
   fi
 done
 
+# By default, the script returns `0`. If any check below failed, the
+# exit code is set to `1`.
+exit_code=0
+
+# Test whether there are any files that are not encoded properly.
+if [ "$line_ending_counter" -gt "0" ]; then
+  echo "${bold}"
+  echo "----------------------------------------------------------------------"
+  echo "${reset}"
+  echo "${yellow}${bold}Warning:${reset}" \
+       "${bold}Some Haskell files don't use Unix line endings.${reset}"
+  echo " |"
+  echo " | Run the ${bold}./tool/format-code.sh${reset} script to normalize"
+  echo " | line endings automatically."
+  exit_code=1
+fi
+
 # Test whether there are any files that need formatting.
-if [ "$counter" -gt "0" ]; then
+if [ "$format_counter" -gt "0" ]; then
   echo "${bold}"
   echo "----------------------------------------------------------------------"
   echo "${reset}"
@@ -62,5 +104,8 @@ if [ "$counter" -gt "0" ]; then
   echo " |"
   echo " | Run the ${bold}./tool/format-code.sh${reset} script to format all"
   echo " | files automatically."
-  exit 1
+  exit_code=1
 fi
+
+# If any check above failed, the script exists with error code `1`.
+exit "$exit_code"

--- a/tool/format-code.sh
+++ b/tool/format-code.sh
@@ -37,19 +37,54 @@ fi
 
 # Format all given Haskell files that are tracked by `git` using `brittany`.
 for file in $(find "${files[@]}" -name '*.hs' -type f); do
-  if git ls-files --error-unmatch "$file" >/dev/null 2>&1; then
+  if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1 ||
+       git ls-files --error-unmatch "$file" >/dev/null 2>&1; then
     echo -n "Formatting ${bold}$file${reset} ... "
-    hash_before=$(sha256sum "$file")
-    brittany --write-mode=inplace "$file"
-    if [ "$?" == "0" ]; then
-      hash_after=$(sha256sum "$file")
-      if [ "$hash_before" == "$hash_after" ]; then
-        echo "${bold}UNCHANGED${reset}"
-      else
-        echo "${green}${bold}DONE${reset}"
+    unchanged=0
+
+    # Convert Windows line endings (CRLF) to Unix line endings (LF) by
+    # removing all carriage return (CR) bytes.
+    temp_file=$(mktemp)
+    cp "$file" "$temp_file"
+    hash_before=$(sha256sum "$temp_file")
+    tr -d '\r' <"$file" >"$temp_file"
+    if [ "$?" -eq "0" ]; then
+      hash_after=$(sha256sum "$temp_file")
+      if [ "$hash_before" != "$hash_after" ]; then
+        echo -n "${yellow}${bold}NORMALIZED LINE ENDINGS${reset}"
+        unchanged=1
       fi
     else
       echo "${red}${bold}ERROR${reset}"
+      continue
     fi
+
+    # Format code with Brittany.
+    hash_before=$(sha256sum "$temp_file")
+    brittany --write-mode=inplace "$temp_file"
+    if [ "$?" -eq "0" ]; then
+      hash_after=$(sha256sum "$temp_file")
+      if [ "$hash_before" != "$hash_after" ]; then
+        if [ "$unchanged" -ne "0" ]; then
+          echo -n " and "
+        fi
+        echo -n "${green}${bold}HAS BEEN FORMATTED${reset}"
+        unchanged=1
+      fi
+    else
+      echo "${red}${bold}ERROR${reset}"
+      continue
+    fi
+
+    # Overwrite file if it has changed and clean up temporary file otherwise.
+    if [ "$unchanged" -eq "0" ]; then
+      echo "${bold}UNCHANGED${reset}"
+      rm "$temp_file"
+    else
+      echo ""
+      mv "$temp_file" "$file"
+    fi
+  else
+    echo "Skipping ${bold}$file${reset} ... ${bold}NOT TRACKED${reset}"
   fi
 done

--- a/tool/format-code.sh
+++ b/tool/format-code.sh
@@ -76,7 +76,7 @@ for file in $(find "${files[@]}" -name '*.hs' -type f); do
       continue
     fi
 
-    # Overwrite file if it has changed and clean up temporary file otherwise.
+    # Overwrite file if it has changed and clean up the temporary file otherwise.
     if [ "$unchanged" -eq "0" ]; then
       echo "${bold}UNCHANGED${reset}"
       rm "$temp_file"

--- a/tool/run.sh
+++ b/tool/run.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# This script can be used to run the pattern matching compiler for debugging
+# purposes. It compiles the executable using Cabal. The command line options
+# are forwarded to the pattern matching compiler's executable.
+#
+# During debugging the `-Wwarn` flag of GHC is set such that warnings are not
+# fatal. However, the executable is intended to compile without warnings, in
+# production. Thus, the `-Wall` and `-Werror` flags are set by default.
+# Before local changes are pushed, all warnings should be fixed. Otherwise,
+# the CI pipeline will fail.
+
+# Change into the package's root directory.
+script=$(realpath "$0")
+script_dir=$(dirname "$script")
+root_dir=$(dirname "$script_dir")
+cd "$root_dir"
+
+# Disable fatal warnings and forward arguments to the executable.
+cabal new-run exe:haskell-src-transformations --ghc-option -Wwarn -- "$@"


### PR DESCRIPTION
<!--
  Have you read our Code of Conduct?
  By filing an issue or pull request, you are expected to comply with it, including treating everyone with respect:
  https://github.com/FreeProving/guidelines/blob/main/CODE_OF_CONDUCT.md
-->

### Issue

<!--
  Link to the issue that this pull request addresses.
  If there is not yet a corresponding issue, please open a new issue and then link to that issue in your pull request.
  Give any additional information that is not covered by the linked issue but might be important for the reviewer.
-->
Closes #14.

### Description of the Change

<!--
  Give a short summary of the changes you made to handle the issue.
  Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.
-->
The [`./tool/run.sh` script from the Free Compiler](https://github.com/FreeProving/free-compiler/blob/477f0f5d898c34bc34827827895118a824127968/tool/run.sh) has been copied to this repository and adapted accordingly. Thus, the pattern matching compiler's command line interface can be executed without installation and without typing a long Cabal command now. Documentation for the script has been added to the `README.md`. Other scripts for formatting source code have been updated to their latest version from the Free Compiler. 

### Verification Process

<!--
  What process did you follow to verify that your change has the desired effects and has not introduced any regressions?
  Describe the actions you performed (including input you checked, tests you created, commands you ran, etc.), and describe the results you observed.
-->
I've used the scripts during development of #25 and noticed no issues so far.
