### PR TITLE
Use `Report` effect instead of `error`

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -19,6 +19,8 @@
 
 # Aliases for qualified imports.
 - modules:
-  - {name: [ HST.Frontend.Syntax ], as: S}
+  - {name: [ Data.Map.Strict ], as: Map}
   - {name: [ HST.Frontend.FromHSE ], as: FromHSE}
+  - {name: [ HST.Frontend.Syntax ], as: S}
   - {name: [ HST.Frontend.ToHSE ], as: ToHSE}
+  - {name: [ Language.Haskell.Exts ], as: HSE}

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -19,7 +19,6 @@
 
 # Aliases for qualified imports.
 - modules:
-  - {name: [ HST.CoreAlgorithm ], as: CA}
   - {name: [ HST.Frontend.Syntax ], as: S}
   - {name: [ HST.Frontend.FromHSE ], as: FromHSE}
   - {name: [ HST.Frontend.ToHSE ], as: ToHSE}

--- a/haskell-src-transformations.cabal
+++ b/haskell-src-transformations.cabal
@@ -84,6 +84,7 @@ library
                     , HST.Effect.PatternStack
                     , HST.Effect.Report
                     , HST.Environment
+                    , HST.Environment.LookupOrReport
                     , HST.Environment.Prelude
                     , HST.Environment.Renaming
                     , HST.Options

--- a/haskell-src-transformations.cabal
+++ b/haskell-src-transformations.cabal
@@ -87,6 +87,8 @@ library
                     , HST.Environment.Prelude
                     , HST.Environment.Renaming
                     , HST.Options
+                    , HST.Util.PrettyName
+                    , HST.Util.Predicates
                     , HST.Util.Selectors
 
 -- Build configuration for the command line interface.

--- a/haskell-src-transformations.cabal
+++ b/haskell-src-transformations.cabal
@@ -81,6 +81,7 @@ library
                     , HST.Effect.Env
                     , HST.Effect.Fresh
                     , HST.Effect.GetOpt
+                    , HST.Effect.PatternStack
                     , HST.Effect.Report
                     , HST.Environment
                     , HST.Environment.Prelude

--- a/haskell-src-transformations.cabal
+++ b/haskell-src-transformations.cabal
@@ -87,6 +87,7 @@ library
                     , HST.Environment.Prelude
                     , HST.Environment.Renaming
                     , HST.Options
+                    , HST.Util.Selectors
 
 -- Build configuration for the command line interface.
 executable haskell-src-transformations

--- a/src/exe/Main.hs
+++ b/src/exe/Main.hs
@@ -138,7 +138,7 @@ processInputFile inputFile = do
   intermediateModule <- FromHSE.transformModule inputModule
   outputModule       <- runEnv . runFresh $ do
     intermediateModule' <- processModule intermediateModule
-    return $ ToHSE.transformModule inputModule intermediateModule'
+    return $ ToHSE.transformModule intermediateModule'
   maybeOutputDir <- getOpt optOutputDir
   case maybeOutputDir of
     Just outputDir -> do

--- a/src/exe/Main.hs
+++ b/src/exe/Main.hs
@@ -134,9 +134,9 @@ processInputFile
   :: Members '[Embed IO, GetOpt, Report] r => FilePath -> Sem r ()
 processInputFile inputFile = do
   input <- embed $ readFile inputFile
-  let inputModule        = HSE.fromParseResult (HSE.parseModule input)
-      intermediateModule = FromHSE.transformModule inputModule
-  outputModule <- runEnv . runFresh $ do
+  let inputModule = HSE.fromParseResult (HSE.parseModule input)
+  intermediateModule <- FromHSE.transformModule inputModule
+  outputModule       <- runEnv . runFresh $ do
     intermediateModule' <- processModule intermediateModule
     return $ ToHSE.transformModule inputModule intermediateModule'
   maybeOutputDir <- getOpt optOutputDir

--- a/src/lib/HST/Application.hs
+++ b/src/lib/HST/Application.hs
@@ -157,7 +157,7 @@ collectDataInfo (S.Module decls) = mapM_ collectDataDecl decls
 --   Leaves the environment unchanged, if the given declaration is not a
 --   data type declaration.
 collectDataDecl :: Member (Env a) r => S.Decl a -> Sem r ()
-collectDataDecl (S.DataDecl dataName conDecls) = do
+collectDataDecl (S.DataDecl _ dataName conDecls) = do
   let dataQName  = S.UnQual S.NoSrcSpan dataName
       conEntries = map (makeConEntry dataQName) conDecls
   modifyEnv $ insertDataEntry DataEntry

--- a/src/lib/HST/Application.hs
+++ b/src/lib/HST/Application.hs
@@ -140,7 +140,7 @@ useAlgo ms = do
   fromUnguardedRhs :: Member Report r => S.Rhs a -> Sem r (S.Exp a)
   fromUnguardedRhs (S.UnGuardedRhs _ expr) = return expr
   fromUnguardedRhs (S.GuardedRhss _ _) =
-    reportFatal $ Message Internal "Expected unguarded right hand side."
+    reportFatal $ Message Internal "Expected unguarded right-hand side."
 
 -------------------------------------------------------------------------------
 -- Environment Initialization                                                --

--- a/src/lib/HST/Application.hs
+++ b/src/lib/HST/Application.hs
@@ -18,7 +18,7 @@ import           Polysemy                       ( Member
 
 import           HST.CoreAlgorithm              ( Eqs
                                                 , match
-                                                , err
+                                                , defaultErrorExp
                                                 , isCons
                                                 )
 import           HST.Effect.Env                 ( Env
@@ -117,7 +117,7 @@ useAlgo ms = do
   eqs <- mapM matchToEquation ms
   let funArity = (length . fst . head) eqs
   nVars <- replicateM funArity (freshVarPat genericFreshPrefix)
-  nExp  <- match nVars eqs err
+  nExp  <- match nVars eqs defaultErrorExp
   nExp' <- ifM (getOpt optOptimizeCase) (optimize nExp) (return nExp)
   return $ S.Match S.NoSrcSpan
                    mname

--- a/src/lib/HST/Application.hs
+++ b/src/lib/HST/Application.hs
@@ -113,14 +113,14 @@ useAlgo
   => [S.Match a]
   -> Sem r (S.Match a)
 useAlgo ms = do
-  let mname = getMatchName ms
   eqs <- mapM matchToEquation ms
-  let funArity = (length . fst . head) eqs
-  nVars <- replicateM funArity (freshVarPat genericFreshPrefix)
+  let name  = getMatchName (head ms)
+      arity = length (fst (head eqs))
+  nVars <- replicateM arity (freshVarPat genericFreshPrefix)
   nExp  <- match nVars eqs defaultErrorExp
   nExp' <- ifM (getOpt optOptimizeCase) (optimize nExp) (return nExp)
   return $ S.Match S.NoSrcSpan
-                   mname
+                   name
                    nVars
                    (S.UnGuardedRhs S.NoSrcSpan nExp')
                    Nothing

--- a/src/lib/HST/Application.hs
+++ b/src/lib/HST/Application.hs
@@ -31,11 +31,7 @@ import           HST.Effect.Fresh               ( Fresh
 import           HST.Effect.GetOpt              ( GetOpt
                                                 , getOpt
                                                 )
-import           HST.Effect.Report              ( Message(Message)
-                                                , Report
-                                                , Severity(Internal)
-                                                , reportFatal
-                                                )
+import           HST.Effect.Report              ( Report )
 import           HST.Environment                ( ConEntry(..)
                                                 , DataEntry(..)
                                                 , insertConEntry
@@ -49,6 +45,7 @@ import           HST.Feature.GuardElimination   ( getMatchName
 import           HST.Feature.Optimization       ( optimize )
 import qualified HST.Frontend.Syntax           as S
 import           HST.Options                    ( optOptimizeCase )
+import           HST.Util.Selectors             ( fromUnguardedRhs )
 
 -------------------------------------------------------------------------------
 -- Application of Core Algorithm                                             --
@@ -135,12 +132,6 @@ useAlgo ms = do
   matchToEquation (S.InfixMatch _ pat _ pats rhs _) = do
     expr <- fromUnguardedRhs rhs
     return (pat : pats, expr)
-
-  -- | Gets the expressions of the given right-hand side of a rule.
-  fromUnguardedRhs :: Member Report r => S.Rhs a -> Sem r (S.Exp a)
-  fromUnguardedRhs (S.UnGuardedRhs _ expr) = return expr
-  fromUnguardedRhs (S.GuardedRhss _ _) =
-    reportFatal $ Message Internal "Expected unguarded right-hand side."
 
 -------------------------------------------------------------------------------
 -- Environment Initialization                                                --

--- a/src/lib/HST/Application.hs
+++ b/src/lib/HST/Application.hs
@@ -75,9 +75,9 @@ useAlgoModule
   :: (Members '[Env a, Fresh, GetOpt, Report] r, S.EqAST a)
   => S.Module a
   -> Sem r (S.Module a)
-useAlgoModule (S.Module ds) = do
-  dcls <- mapM useAlgoDecl ds
-  return $ S.Module dcls
+useAlgoModule (S.Module s origModuleHead decls) = do
+  decls' <- mapM useAlgoDecl decls
+  return $ S.Module s origModuleHead decls'
 
 -- | Applies the core algorithm on the given declaration.
 useAlgoDecl
@@ -149,7 +149,7 @@ useAlgo ms = do
 -- | Initializes the environment with the data types declared in the given
 --   module.
 collectDataInfo :: Member (Env a) r => S.Module a -> Sem r ()
-collectDataInfo (S.Module decls) = mapM_ collectDataDecl decls
+collectDataInfo (S.Module _ _ decls) = mapM_ collectDataDecl decls
 
 -- | Inserts entries for the data type and constructors declared by the given
 --   declaration into the environment.
@@ -157,7 +157,7 @@ collectDataInfo (S.Module decls) = mapM_ collectDataDecl decls
 --   Leaves the environment unchanged, if the given declaration is not a
 --   data type declaration.
 collectDataDecl :: Member (Env a) r => S.Decl a -> Sem r ()
-collectDataDecl (S.DataDecl _ dataName conDecls) = do
+collectDataDecl (S.DataDecl _ _ dataName conDecls) = do
   let dataQName  = S.UnQual S.NoSrcSpan dataName
       conEntries = map (makeConEntry dataQName) conDecls
   modifyEnv $ insertDataEntry DataEntry

--- a/src/lib/HST/CoreAlgorithm.hs
+++ b/src/lib/HST/CoreAlgorithm.hs
@@ -3,7 +3,7 @@
 
 module HST.CoreAlgorithm
   ( match
-  , err
+  , defaultErrorExp
   , translatePVar
   , Eqs
   , isPVar
@@ -63,8 +63,8 @@ import           HST.Options                    ( optTrivialCase )
 type Eqs a = ([S.Pat a], S.Exp a)
 
 -- | The default error expression to insert for pattern matching failures.
-err :: S.Exp a
-err =
+defaultErrorExp :: S.Exp a
+defaultErrorExp =
   S.Var S.NoSrcSpan (S.UnQual S.NoSrcSpan (S.Ident S.NoSrcSpan "undefined"))
 
 -- | Compiles the given equations of a function declaration to a single
@@ -191,8 +191,8 @@ computeAlts x xs eqs er = do
     zs -> do
       b <- getOpt optTrivialCase
       if b
-        then -- TODO is 'err' correct? Why not 'er'?
-             return $ alts ++ [S.alt (S.PWildCard S.NoSrcSpan) err]
+        then -- TODO is 'defaultErrorExp' correct? Why not 'er'?
+             return $ alts ++ [S.alt (S.PWildCard S.NoSrcSpan) defaultErrorExp]
         else do
           z <- createAltsFromConstr x zs er
           -- TODO currently not sorted (reversed)

--- a/src/lib/HST/CoreAlgorithm.hs
+++ b/src/lib/HST/CoreAlgorithm.hs
@@ -9,6 +9,7 @@ module HST.CoreAlgorithm
   , isPVar
   , isCons
   , getPVarName
+  , getQName
   , getQNamePat
   -- * Testing interface
   , compareCons

--- a/src/lib/HST/CoreAlgorithm.hs
+++ b/src/lib/HST/CoreAlgorithm.hs
@@ -4,13 +4,7 @@
 module HST.CoreAlgorithm
   ( match
   , defaultErrorExp
-  , translatePVar
   , Eqs
-  , isPVar
-  , isCons
-  , getPVarName
-  , getQName
-  , getQNamePat
   -- * Testing interface
   , compareCons
   )
@@ -21,23 +15,25 @@ import           Data.List                      ( (\\)
                                                 , partition
                                                 , groupBy
                                                 )
-import           Data.Maybe                     ( fromJust )
 import           Data.Function                  ( on )
 import           Polysemy                       ( Member
                                                 , Members
                                                 , Sem
                                                 )
 
-import           HST.Effect.Env                 ( Env
-                                                , inEnv
-                                                )
+import           HST.Effect.Env                 ( Env )
 import           HST.Effect.Fresh               ( Fresh
-                                                , freshIdent
                                                 , freshVarPat
                                                 , genericFreshPrefix
                                                 )
 import           HST.Effect.GetOpt              ( GetOpt
                                                 , getOpt
+                                                )
+import           HST.Effect.Report              ( Message(Message)
+                                                , Report
+                                                , Severity(Error, Internal)
+                                                , failToReport
+                                                , reportFatal
                                                 )
 import           HST.Environment                ( ConEntry
                                                 , DataEntry
@@ -46,8 +42,9 @@ import           HST.Environment                ( ConEntry
                                                 , conEntryName
                                                 , conEntryType
                                                 , dataEntryCons
-                                                , lookupConEntry
-                                                , lookupDataEntry
+                                                )
+import           HST.Environment.LookupOrReport ( lookupConEntryOrReport
+                                                , lookupDataEntryOrReport
                                                 )
 import           HST.Environment.Renaming       ( subst
                                                 , tSubst
@@ -56,12 +53,31 @@ import           HST.Environment.Renaming       ( subst
                                                 )
 import qualified HST.Frontend.Syntax           as S
 import           HST.Options                    ( optTrivialCase )
+import           HST.Util.Predicates            ( isConPat
+                                                , isVarPat
+                                                )
+import           HST.Util.Selectors             ( getAltConName
+                                                , getMaybePatConName
+                                                , getPatVarName
+                                                )
+
+-------------------------------------------------------------------------------
+-- Equations                                                                 --
+-------------------------------------------------------------------------------
 
 -- | A type that represents a single equation of a function declaration.
 --
 --   An equation is characterized by the argument patterns and the right-hand
 --   side.
 type Eqs a = ([S.Pat a], S.Exp a)
+
+-- | Gets the first pattern of the pattern list of the given equation.
+firstPat :: Eqs a -> S.Pat a
+firstPat = head . fst
+
+-------------------------------------------------------------------------------
+-- Wadler's Algorithm                                                        --
+-------------------------------------------------------------------------------
 
 -- | The default error expression to insert for pattern matching failures.
 defaultErrorExp :: S.Exp a
@@ -75,7 +91,7 @@ defaultErrorExp =
 --   All equations must have the same number of patterns as the given list
 --   of fresh variable patterns.
 match
-  :: (Members '[Env a, Fresh, GetOpt] r, S.EqAST a)
+  :: (Members '[Env a, Fresh, GetOpt, Report] r, S.EqAST a)
   => [S.Pat a] -- ^ Fresh variable patterns.
   -> [Eqs a]   -- ^ The equations of the function declaration.
   -> S.Exp a   -- ^ The error expression for pattern-matching failures.
@@ -84,69 +100,42 @@ match [] (([], e) : _) _  = return e  -- Rule 3a: All patterns matched.
 match [] []            er = return er -- Rule 3b: Pattern-matching failure.
 match vars@(x : xs) eqs er
   | -- Rule 1: Pattern list of all equations starts with a variable pattern.
-    allVars eqs = do
+    allVarPats eqs = do
     eqs' <- mapM (substVars x) eqs
     match xs eqs' er
   | -- Rule 2: Pattern lists of all equations starts with a constructor pattern.
-    allCons eqs = makeRhs x xs eqs er
+    allConPats eqs = makeRhs x xs eqs er
   | -- Rule 4: Pattern lists of some equations start with a variable pattern
     -- and others start with a constructor pattern.
     --
     -- TODO This is probably causing the infinite loops when there are
     --      unsupported patterns.
-    otherwise = createRekMatch vars er (groupPat eqs)
-match [] _ _ = error "match: equations have different number of arguments"
+    otherwise = createRekMatch vars er (groupByFirstPatType eqs)
+match [] _ _ =
+  reportFatal $ Message Error $ "Equations have different number of arguments."
 
 -- | Substitutes all occurrences of the variable bound by the first pattern
 --   (must be a variable or wildcard pattern) of the given equation by the
 --   fresh variable bound by the given variable pattern on the right-hand side
 --   of the equation.
-substVars :: Member Fresh r => S.Pat a -> Eqs a -> Sem r (Eqs a)
+substVars :: Members '[Fresh, Report] r => S.Pat a -> Eqs a -> Sem r (Eqs a)
 substVars pv (p : ps, e) = do
-  s1 <- getPVarName p
-  s2 <- getPVarName pv
+  s1 <- getPatVarName p
+  s2 <- getPatVarName pv
   let sub = subst s1 s2
   return (ps, rename sub e)
-substVars _ _ = error "substVars: expected equation with at least one pattern"
-
--- | Extracts the name of the variable bound by the given variable pattern.
---
---   Returns a fresh variable for wildcard patterns.
---   The given pattern must be a variable or wildcard pattern.
-getPVarName :: Member Fresh r => S.Pat a -> Sem r String
-getPVarName (S.PVar _ pname) = getNameStr pname
- where
-  getNameStr (S.Ident  _ str) = return str
-  getNameStr (S.Symbol _ str) = return str
-getPVarName (S.PWildCard _) = freshIdent genericFreshPrefix
-getPVarName _ = error "getPVarName: expected variable or wildcard pattern"
-
--- | Groups the given equations based on the type of their first pattern.
---
---   The order of the equations is not changed, i.e., concatenation of the
---   resulting groups yields the original list of equations.
-
---   Two equations are in the same group only if their pattern lists both
---   start with a variable pattern or both start with a constructor pattern.
-groupPat :: [Eqs a] -> [[Eqs a]]
-groupPat = groupBy ordPats
-  where ordPats (ps, _) (qs, _) = isPVar (head ps) && isPVar (head qs)
-
--- | Tests whether the given pattern is a variable pattern.
---
---   TODO shouldn't this return @True@ for wildcard patterns, too?
---   What's the difference to @isVar@?
-isPVar :: S.Pat a -> Bool
-isPVar (S.PVar _ _) = True
-isPVar _            = False
+substVars _ ([], _) =
+  reportFatal
+    $ Message Internal
+    $ "Expected equation with at least one pattern."
 
 -- | Applies 'match' to every group of equations where the error expression
 --   is the 'match' result of the next group.
 createRekMatch
-  :: (Members '[Env a, Fresh, GetOpt] r, S.EqAST a)
+  :: (Members '[Env a, Fresh, GetOpt, Report] r, S.EqAST a)
   => [S.Pat a] -- ^ Fresh variable patterns.
   -> S.Exp a   -- ^ The error expression for pattern-matching failures.
-  -> [[Eqs a]] -- ^ Groups of equations (see 'groupPat').
+  -> [[Eqs a]] -- ^ Groups of equations (see 'groupByFirstPatType').
   -> Sem r (S.Exp a)
 createRekMatch vars er =
   foldr (\eqs mrhs -> mrhs >>= match vars eqs) (return er)
@@ -154,7 +143,7 @@ createRekMatch vars er =
 -- | Creates a case expression that performs pattern matching on the variable
 --   bound by the given variable pattern.
 makeRhs
-  :: (Members '[Env a, Fresh, GetOpt] r, S.EqAST a)
+  :: (Members '[Env a, Fresh, GetOpt, Report] r, S.EqAST a)
   => S.Pat a   -- ^ The fresh variable pattern to match.
   -> [S.Pat a] -- ^ The remaing fresh variable patterns.
   -> [Eqs a]   -- ^ The equations.
@@ -162,12 +151,7 @@ makeRhs
   -> Sem r (S.Exp a)
 makeRhs x xs eqs er = do
   alts <- computeAlts x xs eqs er
-  return (S.Case S.NoSrcSpan (translatePVar x) alts)
-
--- | Converts the given variable pattern to a variable expression.
-translatePVar :: S.Pat a -> S.Exp a
-translatePVar (S.PVar _ vname) = S.var vname
-translatePVar _ = error "translatePVar: expected variable pattern" --, got" ++ show p)
+  return (S.Case S.NoSrcSpan (S.patToExp x) alts)
 
 -- TODO remove redundand types
 
@@ -178,85 +162,71 @@ translatePVar _ = error "translatePVar: expected variable pattern" --, got" ++ s
 --   If trivial case completion is not enabled, one alternative is added for
 --   every missing constructor.
 computeAlts
-  :: (Members '[Env a, Fresh, GetOpt] r, S.EqAST a)
+  :: (Members '[Env a, Fresh, GetOpt, Report] r, S.EqAST a)
   => S.Pat a   -- ^ The variable pattern that binds the matched variable.
   -> [S.Pat a] -- ^ The remaing fresh variable patterns.
   -> [Eqs a]   -- ^ The equations to generate alternatives for.
   -> S.Exp a   -- ^ The error expression for pattern-matching failures.
   -> Sem r [S.Alt a]
 computeAlts x xs eqs er = do
-  alts <- mapM (computeAlt x xs er) (groupByCons eqs)
-  mxs  <- getMissingConstrs alts
-  case mxs of
-    [] -> return alts
-    zs -> do
+  alts        <- mapM (computeAlt x xs er) (groupByCons eqs)
+  missingCons <- identifyMissingCons alts
+  if null missingCons
+    then return alts
+    else do
       b <- getOpt optTrivialCase
       if b
         then -- TODO is 'defaultErrorExp' correct? Why not 'er'?
              return $ alts ++ [S.alt (S.PWildCard S.NoSrcSpan) defaultErrorExp]
         else do
-          z <- createAltsFromConstr x zs er
+          z <- createAltsForMissingCons x missingCons er
           -- TODO currently not sorted (reversed)
           return $ alts ++ z
 
+-------------------------------------------------------------------------------
+-- Case Completion                                                           --
+-------------------------------------------------------------------------------
+
 -- | Looks up the constructors of the data type that is matched by the given
 --   @case@ expression alternatives for which there are no alternatives already.
-getMissingConstrs :: Member (Env a) r => [S.Alt a] -> Sem r [ConEntry a]
-getMissingConstrs []   = error "getMissingConstrs: empty case"
-getMissingConstrs alts = do
-  let matchedConNames = map getQName alts
-  dataEntry <- findDataEntry (head matchedConNames)
+identifyMissingCons
+  :: Members '[Env a, Report] r => [S.Alt a] -> Sem r [ConEntry a]
+identifyMissingCons [] =
+  reportFatal
+    $  Message Error
+    $  "Could not identify missing constructors: "
+    ++ "Empty case expressions are not supported."
+identifyMissingCons alts = do
+  matchedConNames <- mapM getAltConName alts
+  dataEntry       <- findDataEntry (head matchedConNames)
   let missingConNames = dataEntryCons dataEntry \\ matchedConNames
-  mapM (fmap fromJust . inEnv . lookupConEntry) missingConNames
+  mapM lookupConEntryOrReport missingConNames
 
 -- | Looks up the data type for the given constructor in the given environment.
-findDataEntry :: Member (Env a) r => S.QName a -> Sem r (DataEntry a)
+findDataEntry :: Members '[Env a, Report] r => S.QName a -> Sem r (DataEntry a)
 findDataEntry conName = do
-  maybeDataName <- inEnv $ fmap conEntryType . lookupConEntry conName
-  case maybeDataName of
-    Nothing       -> error "findDataType: constructor not in scope"
-    Just dataName -> do
-      maybeDataEntry <- inEnv $ lookupDataEntry dataName
-      case maybeDataEntry of
-        Nothing        -> error "findDataType: data type not in scope"
-        Just dataEntry -> return dataEntry
-
--- | Gets the name of the constructor matched by the given @case@ expression
---   alternative.
-getQName :: S.Alt a -> S.QName a
-getQName (S.Alt _ p _ _) = getQNamePat p
-
--- | Gets the name of a constructor pattern.
---
---   Returns the 'S.Special' names for special patterns such as lists and tuples.
-getQNamePat :: S.Pat a -> S.QName a
-getQNamePat (S.PApp _ qn _) = qn
-getQNamePat (S.PInfixApp _ _ qn _) = qn
-getQNamePat (S.PList _ _) = S.Special S.NoSrcSpan (S.ListCon S.NoSrcSpan)
-getQNamePat (S.PWildCard _) = S.Special S.NoSrcSpan (S.ExprHole S.NoSrcSpan) -- TODO aren't wildcard pattern considers variable and not constructor patterns?
-getQNamePat (S.PTuple _ bxd ps) =
-  S.Special S.NoSrcSpan (S.TupleCon S.NoSrcSpan bxd (length ps))
-getQNamePat _ = error "getQNamePat unsuported Pattern"
+  dataName <- conEntryType <$> lookupConEntryOrReport conName
+  lookupDataEntryOrReport dataName
 
 -- TODO refactor with smartcons
 
 -- | Creates new @case@ expression alternatives for the given missing
 --   constructors.
-createAltsFromConstr
+createAltsForMissingCons
   :: (Member Fresh r, S.EqAST a)
   => S.Pat a         -- ^ The fresh variable matched by the @case@ expression.
   -> [ConEntry a]    -- ^ The missing constructors to generate alternatives for.
   -> S.Exp a         -- ^ The error expression for pattern-matching failures.
   -> Sem r [S.Alt a]
-createAltsFromConstr x cs er = mapM (createAltFromConstr x er) cs
+createAltsForMissingCons x cs er = mapM (createAltForMissingCon x er) cs
  where
-  createAltFromConstr
+  createAltForMissingCon
     :: (Member Fresh r, S.EqAST a)
     => S.Pat a
     -> S.Exp a
     -> ConEntry a
     -> Sem r (S.Alt a)
-  createAltFromConstr pat e conEntry = do
+  createAltForMissingCon pat e conEntry = do
     nvars <- replicateM (conEntryArity conEntry)
                         (freshVarPat genericFreshPrefix)
     let p
@@ -265,10 +235,25 @@ createAltsFromConstr x cs er = mapM (createAltFromConstr x er) cs
                                                    (conEntryName conEntry)
                                                    (nvars !! 1)
           | otherwise = S.PApp S.NoSrcSpan (conEntryName conEntry) nvars
-        p'   = translateApp p
-        pat' = translatePVar pat
+        p'   = S.patToExp p
+        pat' = S.patToExp pat
         e'   = substitute (tSubst pat' p') e
     return (S.alt p e')
+
+-------------------------------------------------------------------------------
+-- Grouping                                                                  --
+-------------------------------------------------------------------------------
+
+-- | Groups the given equations based on the type of their first pattern.
+--
+--   The order of the equations is not changed, i.e., concatenation of the
+--   resulting groups yields the original list of equations.
+
+--   Two equations are in the same group only if their pattern lists both
+--   start with a variable pattern or both start with a constructor pattern.
+groupByFirstPatType :: [Eqs a] -> [[Eqs a]]
+groupByFirstPatType = groupBy ordPats
+  where ordPats (ps, _) (qs, _) = isVarPat (head ps) && isVarPat (head qs)
 
 -- | Groups the given equations based on the constructor matched by their
 --   first pattern.
@@ -276,7 +261,7 @@ createAltsFromConstr x cs er = mapM (createAltFromConstr x er) cs
 --   The order of equations that match the same constructor (i.e., within
 --   groups) is preserved.
 groupByCons :: [Eqs a] -> [[Eqs a]]
-groupByCons = groupBy2 select
+groupByCons = groupBy2 startWithSameCons
 
 -- | A version of 'groupBy' that produces only one group for all
 --   elements that are equivalent under the given predicate.
@@ -306,28 +291,17 @@ groupBy2 = groupBy2' []
 
 -- | Tests whether the pattern lists of the given equations start with the same
 --   constructor.
-select :: Eqs a -> Eqs a -> Bool
-select (ps, _) (qs, _) = compareCons (head ps) (head qs)
+startWithSameCons :: Eqs a -> Eqs a -> Bool
+startWithSameCons (ps, _) (qs, _) = compareCons (head ps) (head qs)
 
 -- | Tests whether the given patterns match the same constructor or both match
 --   the wildcard pattern.
 compareCons :: S.Pat a -> S.Pat a -> Bool
-compareCons = (==) `on` consName
+compareCons = (==) `on` getMaybePatConName
 
--- | Returns the qualified name of the constructor of the given pattern or
---   @Nothing@ if it is a wildcard pattern.
-consName :: S.Pat a -> Maybe (S.QName a)
-consName (S.PApp _ qn _       ) = return qn
-consName (S.PInfixApp _ _ qn _) = return qn
-consName (S.PParen _ pat      ) = consName pat
-consName (S.PList _ []) =
-  return $ S.Special S.NoSrcSpan $ S.ListCon S.NoSrcSpan
-consName (S.PList _ (_ : _)) =
-  return $ S.Special S.NoSrcSpan $ S.Cons S.NoSrcSpan
-consName (S.PTuple _ bxd ps) =
-  return $ S.Special S.NoSrcSpan $ S.TupleCon S.NoSrcSpan bxd $ length ps
-consName (S.PWildCard _) = Nothing
-consName _               = error "consName: unsupported pattern" -- \"" ++ P.prettyPrint pat ++ "\""
+-------------------------------------------------------------------------------
+-- Code Generation                                                           --
+-------------------------------------------------------------------------------
 
 -- | Creates an alternative for a @case@ expression for the given group of
 --   equations whose first pattern matches the same constructor.
@@ -340,64 +314,49 @@ consName _               = error "consName: unsupported pattern" -- \"" ++ P.pre
 --   termination check of the free-compiler and can probably be removed
 --   once sharing is implemented.
 computeAlt
-  :: (Members '[Env a, Fresh, GetOpt] r, S.EqAST a)
+  :: (Members '[Env a, Fresh, GetOpt, Report] r, S.EqAST a)
   => S.Pat a   -- ^ The variable pattern that binds the matched variable.
   -> [S.Pat a] -- ^ The remaing fresh variable patterns.
   -> S.Exp a   -- ^ The error expression for pattern-matching failures.
   -> [Eqs a]   -- ^ A group of equations (see 'groupByCons').
   -> Sem r (S.Alt a)
-computeAlt _   _    _  []           = error "computeAlt: no equations"
 computeAlt pat pats er prps@(p : _) = do
   -- oldpats need to be computed for each pattern
   (capp, nvars, _) <- decomposeConPat (firstPat p)
   nprps            <- mapM f prps
-  let sub = tSubst (translatePVar pat) (translateApp capp)
+  let sub = tSubst (S.patToExp pat) (S.patToExp capp)
   res <- match (nvars ++ pats) nprps (substitute sub er)
   let res' = substitute sub res
   return (S.alt capp res')
  where
-  f :: Member Fresh r => Eqs a -> Sem r (Eqs a)
+  f :: Members '[Fresh, Report] r => Eqs a -> Sem r (Eqs a)
   f ([]    , r) = return ([], r) -- potentially unused
   f (v : vs, r) = do
     (_, _, oldpats) <- decomposeConPat v
     return (oldpats ++ vs, r)
-
--- | Converts a constructor application pattern (where the argument patterns
---   are variable or wildcard patterns) to an expression.
-translateApp :: S.Pat a -> S.Exp a
-translateApp (S.PApp _ qn ps) = foldl
-  (\acc x -> S.App S.NoSrcSpan acc (translatePVar x))
-  (S.Con S.NoSrcSpan qn)
-  ps
-translateApp (S.PInfixApp _ p1 qn p2) = S.InfixApp S.NoSrcSpan
-                                                   (translatePVar p1)
-                                                   (S.QConOp S.NoSrcSpan qn)
-                                                   (translatePVar p2)
-translateApp (S.PTuple _ bxd ps) =
-  S.Tuple S.NoSrcSpan bxd $ map translatePVar ps
-translateApp (S.PList _ ps) = S.List S.NoSrcSpan $ map translatePVar ps
-translateApp _              = error "translateApp: Unsupported pattern"
-          -- pat = error ("translateApp does not support: " ++ show pat)
+computeAlt _ _ _ [] =
+  reportFatal $ Message Internal $ "Expected at least one pattern in group."
 
 -- TODO refactor into 2 functions. one for the capp and nvars and one for the
 --      oldpats
 
--- | Replaces the child patterns of a constructor pattern with fresh variable
---   patterns.
+-- | Replaces the child patterns of a pattern with fresh variable patterns.
 --
---   Returns the constructor with replaced child patterns and a list of
---   new and old variable patterns.
+--   Returns the pattern with replaced child patterns and a list of new and
+--   old child patterns.
 decomposeConPat
-  :: Member Fresh r => S.Pat a -> Sem r (S.Pat a, [S.Pat a], [S.Pat a])
+  :: Members '[Fresh, Report] r
+  => S.Pat a
+  -> Sem r (S.Pat a, [S.Pat a], [S.Pat a])
 decomposeConPat (S.PApp _ qname ps) = do
   nvars <- replicateM (length ps) (freshVarPat genericFreshPrefix)
   return (S.PApp S.NoSrcSpan qname nvars, nvars, ps)
-decomposeConPat (S.PInfixApp _ p1 qname p2) = do
-  nvars <- replicateM 2 (freshVarPat genericFreshPrefix)
-  let [nv1, nv2] = nvars
-      ps         = [p1, p2]
+decomposeConPat (S.PInfixApp _ p1 qname p2) = failToReport $ do
+  nvars@[nv1, nv2] <- replicateM 2 (freshVarPat genericFreshPrefix)
+  let ps = [p1, p2]
   return (S.PInfixApp S.NoSrcSpan nv1 qname nv2, nvars, ps)
-decomposeConPat (S.PParen _ p) = decomposeConPat p
+
+-- Decompose patterns with special syntax.
 decomposeConPat (S.PList _ ps)
   | null ps = return (S.PList S.NoSrcSpan [], [], [])
   | otherwise = do
@@ -407,40 +366,24 @@ decomposeConPat (S.PList _ ps)
 decomposeConPat (S.PTuple _ bxd ps) = do
   nvars <- replicateM (length ps) (freshVarPat genericFreshPrefix)
   return (S.PTuple S.NoSrcSpan bxd nvars, nvars, ps)
--- wildcards no longer needed as cons
+
+-- Decompose patterns with parentheses recursively.
+decomposeConPat (S.PParen _ p ) = decomposeConPat p
+
+-- Variable and wildcard patterns don't contain child patterns.
 decomposeConPat (S.PWildCard _) = return (S.PWildCard S.NoSrcSpan, [], [])
-decomposeConPat _               = error "wrong Pattern in decomposeConPat"
+decomposeConPat (S.PVar _ name) = return (S.PVar S.NoSrcSpan name, [], [])
+
+-------------------------------------------------------------------------------
+-- Predicates                                                                --
+-------------------------------------------------------------------------------
 
 -- | Tests whether the pattern lists of all given equations starts with a
 --   variable pattern.
-allVars :: [Eqs a] -> Bool
-allVars = all (isVar . firstPat)
-
--- | Gets the first pattern of the pattern list of the given equation.
-firstPat :: Eqs a -> S.Pat a
-firstPat = head . fst
-
--- | Tests whether the given pattern is a variable or wildcard pattern.
-isVar :: S.Pat a -> Bool
-isVar (S.PVar _ _   ) = True
-isVar (S.PWildCard _) = True
-isVar _               = False
+allVarPats :: [Eqs a] -> Bool
+allVarPats = all (isVarPat . firstPat)
 
 -- | Tests whether the pattern lists of all given equations starts with a
 --   constructor pattern.
-allCons :: [Eqs a] -> Bool
-allCons = all (isCons . firstPat)
-
--- | Tests whether the given pattern is a constructor pattern.
---
---   Special patterns for lists and tuples are also considered constructor
---   patterns.
-isCons :: S.Pat a -> Bool
-isCons p = case p of
-  S.PApp _ _ _        -> True
-  S.PInfixApp _ _ _ _ -> True
-  S.PParen _ p'       -> isCons p'
-  S.PList  _ _        -> True
-  S.PTuple _ _ _      -> True
-  S.PWildCard _       -> False -- Wildcards are now treated as variables
-  _                   -> False
+allConPats :: [Eqs a] -> Bool
+allConPats = all (isConPat . firstPat)

--- a/src/lib/HST/Effect/Fresh.hs
+++ b/src/lib/HST/Effect/Fresh.hs
@@ -20,8 +20,8 @@ module HST.Effect.Fresh
   )
 where
 
-import           Data.Map                       ( Map )
-import qualified Data.Map                      as Map
+import           Data.Map.Strict                ( Map )
+import qualified Data.Map.Strict               as Map
 import           Polysemy                       ( Member
                                                 , Sem
                                                 , makeSem

--- a/src/lib/HST/Effect/PatternStack.hs
+++ b/src/lib/HST/Effect/PatternStack.hs
@@ -1,0 +1,74 @@
+{-# LANGUAGE TemplateHaskell, ScopedTypeVariables #-}
+{-# LANGUAGE LambdaCase, BlockArguments #-}
+
+-- | This module defines an effect for computations that can save patterns
+--   variables have been matched against on a stack.
+
+module HST.Effect.PatternStack
+  ( -- * Effect
+    PatternStack
+    -- * Actions
+  , pushPattern
+  , peekPattern
+  , popPattern
+    -- * Interpretations
+  , runPatternStack
+  )
+where
+
+import           Data.Map                       ( Map )
+import qualified Data.Map                      as Map
+import           Polysemy                       ( Sem
+                                                , makeSem
+                                                , reinterpret
+                                                )
+import           Polysemy.State                 ( State
+                                                , evalState
+                                                , gets
+                                                , modify
+                                                )
+
+
+import qualified HST.Frontend.Syntax           as S
+
+-------------------------------------------------------------------------------
+-- Effect and Actions                                                        --
+-------------------------------------------------------------------------------
+
+-- | An effect capable of pushing and poping patterns variables have been
+--   matched against to a stack.
+data PatternStack a m b where
+  PushPattern ::S.QName a -> S.Pat a -> PatternStack a m ()
+  PeekPattern ::S.QName a -> PatternStack a m (Maybe (S.Pat a))
+  PopPattern ::S.QName a -> PatternStack a m ()
+
+makeSem ''PatternStack
+
+-------------------------------------------------------------------------------
+-- Interpretations                                                           --
+-------------------------------------------------------------------------------
+
+-- | A map of stacks of patterns by variable names.
+type StackMap a = Map (S.QName a) [S.Pat a]
+
+-- | Interprets the given computation by providing one stack for each variable.
+runPatternStack :: Sem (PatternStack a ': r) b -> Sem r b
+runPatternStack = evalState Map.empty . patternStackToState
+ where
+  patternStackToState
+    :: Sem (PatternStack a ': r) b -> Sem (State (StackMap a) ': r) b
+  patternStackToState = reinterpret \case
+    PushPattern name pat -> modify $ Map.alter (maybeCons pat) name
+    PeekPattern name     -> gets $ fmap head . Map.lookup name
+    PopPattern  name     -> modify $ Map.update maybeTail name
+
+  -- | Like @(:)@ but returns @Just@ a singleton list if the given tail is
+  --   @Nothing@.
+  maybeCons :: a -> Maybe [a] -> Maybe [a]
+  maybeCons x Nothing   = Just [x]
+  maybeCons x (Just xs) = Just (x : xs)
+
+  -- | Like @tail@ but returns @Nothing@ if the list is empty.
+  maybeTail :: [a] -> Maybe [a]
+  maybeTail []       = Nothing
+  maybeTail (_ : xs) = Just xs

--- a/src/lib/HST/Effect/PatternStack.hs
+++ b/src/lib/HST/Effect/PatternStack.hs
@@ -16,8 +16,8 @@ module HST.Effect.PatternStack
   )
 where
 
-import           Data.Map                       ( Map )
-import qualified Data.Map                      as Map
+import           Data.Map.Strict                ( Map )
+import qualified Data.Map.Strict               as Map
 import           Polysemy                       ( Sem
                                                 , makeSem
                                                 , reinterpret

--- a/src/lib/HST/Effect/PatternStack.hs
+++ b/src/lib/HST/Effect/PatternStack.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE TemplateHaskell, ScopedTypeVariables #-}
 {-# LANGUAGE LambdaCase, BlockArguments #-}
 
--- | This module defines an effect for computations that can save patterns
---   variables have been matched against on a stack.
+-- | This module defines an effect for computations which can save patterns
+--   that variables have been matched against on a stack.
 
 module HST.Effect.PatternStack
   ( -- * Effect
@@ -35,7 +35,7 @@ import qualified HST.Frontend.Syntax           as S
 -- Effect and Actions                                                        --
 -------------------------------------------------------------------------------
 
--- | An effect capable of pushing and poping patterns variables have been
+-- | An effect capable of pushing and popping patterns that variables have been
 --   matched against to a stack.
 data PatternStack a m b where
   PushPattern ::S.QName a -> S.Pat a -> PatternStack a m ()

--- a/src/lib/HST/Effect/Report.hs
+++ b/src/lib/HST/Effect/Report.hs
@@ -185,6 +185,5 @@ exceptionToReport exceptionToMessage =
 --   > foo = failToReport $ do
 --   >   (x, y) <- bar
 --   >   …
-failToReport
-  :: Member Report r => Sem (Fail ': r) a -> Sem r a
+failToReport :: Member Report r => Sem (Fail ': r) a -> Sem r a
 failToReport = runFail >=> either (reportFatal . Message Internal) return

--- a/src/lib/HST/Environment.hs
+++ b/src/lib/HST/Environment.hs
@@ -17,8 +17,8 @@ module HST.Environment
   )
 where
 
-import           Data.Map                       ( Map )
-import qualified Data.Map                      as Map
+import           Data.Map.Strict                ( Map )
+import qualified Data.Map.Strict               as Map
 
 import qualified HST.Frontend.Syntax           as S
 

--- a/src/lib/HST/Environment.hs
+++ b/src/lib/HST/Environment.hs
@@ -71,9 +71,8 @@ data Environment a = Environment
 
 -- | An empty 'Environment'.
 emptyEnv :: Environment a
-emptyEnv = Environment { envConEntries  = Map.empty
-                       , envDataEntries = Map.empty
-                       }
+emptyEnv =
+  Environment { envConEntries = Map.empty, envDataEntries = Map.empty }
 
 -------------------------------------------------------------------------------
 -- Lookup                                                                    --

--- a/src/lib/HST/Environment/LookupOrReport.hs
+++ b/src/lib/HST/Environment/LookupOrReport.hs
@@ -1,0 +1,61 @@
+-- | This module contains variations of the "HST.Environment" lookup functions
+--   that don't return @Maybe@ values but report fatal error if a data or type
+--   constructor cannot be found in the environment.
+
+module HST.Environment.LookupOrReport
+  ( lookupConEntryOrReport
+  , lookupDataEntryOrReport
+  )
+where
+
+import           Polysemy                       ( Members
+                                                , Sem
+                                                )
+
+import           HST.Effect.Env                 ( Env
+                                                , inEnv
+                                                )
+import           HST.Effect.Report              ( Message(Message)
+                                                , Report
+                                                , Severity(Error)
+                                                , reportFatal
+                                                )
+import           HST.Environment                ( ConEntry
+                                                , DataEntry
+                                                , lookupConEntry
+                                                , lookupDataEntry
+                                                )
+import qualified HST.Frontend.Syntax           as S
+import           HST.Util.PrettyName            ( prettyName )
+
+-- | Looks up the entry of a data constructor with the given name in the
+--   current environment.
+--
+--   Reports a fatal error if the constructor could not be found.
+lookupConEntryOrReport
+  :: Members '[Env a, Report] r => S.QName a -> Sem r (ConEntry a)
+lookupConEntryOrReport conName = do
+  maybeConEntry <- inEnv $ lookupConEntry conName
+  case maybeConEntry of
+    Nothing ->
+      reportFatal
+        $  Message Error
+        $  "Data constructor not in scope: "
+        ++ prettyName conName
+    Just conEntry -> return conEntry
+
+-- | Looks up the entry of a type constructor with the given name in the
+--   current environment.
+--
+--   Reports a fatal error if the constructor could not be found.
+lookupDataEntryOrReport
+  :: Members '[Env a, Report] r => S.QName a -> Sem r (DataEntry a)
+lookupDataEntryOrReport dataName = do
+  maybeDataEntry <- inEnv $ lookupDataEntry dataName
+  case maybeDataEntry of
+    Nothing ->
+      reportFatal
+        $  Message Error
+        $  "Type constructor not in scope: "
+        ++ prettyName dataName
+    Just dataEntry -> return dataEntry

--- a/src/lib/HST/Environment/LookupOrReport.hs
+++ b/src/lib/HST/Environment/LookupOrReport.hs
@@ -1,6 +1,6 @@
 -- | This module contains variations of the "HST.Environment" lookup functions
---   that don't return @Maybe@ values but report fatal error if a data or type
---   constructor cannot be found in the environment.
+--   that don't return @Maybe@ values but report a fatal error if a data or
+--   type constructor cannot be found in the environment.
 
 module HST.Environment.LookupOrReport
   ( lookupConEntryOrReport

--- a/src/lib/HST/Environment/Renaming.hs
+++ b/src/lib/HST/Environment/Renaming.hs
@@ -37,23 +37,23 @@ class TermSubst c where
 
 -- | 'TermSubst' instance for expressions.
 instance TermSubst S.Exp where
-  substitute s expr = case expr of
-    S.Var l qname   -> s (S.Var l qname)
-    S.Con l qname   -> S.Con l qname
-    S.Lit l literal -> S.Lit l literal
-    S.InfixApp l e1 qop e2 ->
-      S.InfixApp l (substitute s e1) qop (substitute s e2)
-    S.NegApp l e     -> S.NegApp l (substitute s e)
-    S.App    l e1 e2 -> S.App l (substitute s e1) (substitute s e2)
-    S.Lambda l ps e  -> S.Lambda l ps (substitute s e)
-    S.Let    l b  e  -> S.Let l b $ substitute s e
-    S.If l e1 e2 e3 ->
-      S.If l (substitute s e1) (substitute s e2) (substitute s e3)
-    S.Case  l e   as   -> S.Case l (substitute s e) (map (substitute s) as)
-    S.Tuple l bxd es   -> S.Tuple l bxd (map (substitute s) es)
-    S.List  l es       -> S.List l (map (substitute s) es)
-    S.Paren l e        -> S.Paren l (substitute s e)
-    S.ExpTypeSig l e t -> S.ExpTypeSig l (substitute s e) t
+  substitute s (S.Var l qname  ) = s (S.Var l qname)
+  substitute _ (S.Con l qname  ) = S.Con l qname
+  substitute _ (S.Lit l literal) = S.Lit l literal
+  substitute s (S.InfixApp l e1 qop e2) =
+    S.InfixApp l (substitute s e1) qop (substitute s e2)
+  substitute s (S.NegApp l e    ) = S.NegApp l (substitute s e)
+  substitute s (S.App    l e1 e2) = S.App l (substitute s e1) (substitute s e2)
+  substitute s (S.Lambda l ps e ) = S.Lambda l ps (substitute s e)
+  substitute s (S.Let    l b  e ) = S.Let l b $ substitute s e
+  substitute s (S.If l e1 e2 e3) =
+    S.If l (substitute s e1) (substitute s e2) (substitute s e3)
+  substitute s (S.Case l e as) =
+    S.Case l (substitute s e) (map (substitute s) as)
+  substitute s (S.Tuple l bxd es  ) = S.Tuple l bxd (map (substitute s) es)
+  substitute s (S.List  l es      ) = S.List l (map (substitute s) es)
+  substitute s (S.Paren l e       ) = S.Paren l (substitute s e)
+  substitute s (S.ExpTypeSig l e t) = S.ExpTypeSig l (substitute s e) t
 
 -- | 'TermSubst' instance for @case@ expression alternatives.
 --
@@ -66,9 +66,13 @@ instance TermSubst S.Alt where
 --   Applies the substitution to the expression on the right-hand side.
 --   There must be no guards.
 instance TermSubst S.Rhs where
-  substitute s rhs = case rhs of
-    S.UnGuardedRhs l e -> S.UnGuardedRhs l (substitute s e)
-    S.GuardedRhss  _ _ -> error "TermSubst: GuardedRhss not supported"
+  substitute s (S.UnGuardedRhs l e) = S.UnGuardedRhs l (substitute s e)
+  substitute s (S.GuardedRhss l grhs) =
+    S.GuardedRhss l (map (substitute s) grhs)
+
+instance TermSubst S.GuardedRhs where
+  substitute s (S.GuardedRhs l e1 e2) =
+    S.GuardedRhs l (substitute s e1) (substitute s e2)
 
 -- | Type class for AST nodes of type @c@ a 'Subst' can be applied to.
 class Rename c where
@@ -77,35 +81,33 @@ class Rename c where
 
 -- | 'Rename' instance for expressions.
 instance Rename (S.Exp a) where
-  rename s expr = case expr of
-    S.Var l qname          -> S.Var l (rename s qname)
-    S.Con l qname          -> S.Con l qname
-    S.Lit l literal        -> S.Lit l literal
-    S.InfixApp l e1 qop e2 -> S.InfixApp l (rename s e1) qop (rename s e2)
-    S.NegApp l e           -> S.NegApp l (rename s e)
-    S.App    l e1 e2       -> S.App l (rename s e1) (rename s e2)
-    S.Lambda l ps e        -> S.Lambda l (map (rename s) ps) (rename s e)
-    S.Let    l b  e        -> S.Let l b $ rename s e
-    S.If l e1 e2 e3        -> S.If l (rename s e1) (rename s e2) (rename s e3)
-    S.Case  l e   as       -> S.Case l (rename s e) (map (rename s) as)
-    S.Tuple l bxd es       -> S.Tuple l bxd (map (rename s) es)
-    S.List  l es           -> S.List l (map (rename s) es)
-    S.Paren l e            -> S.Paren l (rename s e)
-    S.ExpTypeSig l e t     -> S.ExpTypeSig l (rename s e) t
+  rename s (S.Var l qname  ) = S.Var l (rename s qname)
+  rename _ (S.Con l qname  ) = S.Con l qname
+  rename _ (S.Lit l literal) = S.Lit l literal
+  rename s (S.InfixApp l e1 qop e2) =
+    S.InfixApp l (rename s e1) qop (rename s e2)
+  rename s (S.NegApp l e      ) = S.NegApp l (rename s e)
+  rename s (S.App    l e1 e2  ) = S.App l (rename s e1) (rename s e2)
+  rename s (S.Lambda l ps e   ) = S.Lambda l (map (rename s) ps) (rename s e)
+  rename s (S.Let    l b  e   ) = S.Let l b $ rename s e
+  rename s (S.If l e1 e2 e3) = S.If l (rename s e1) (rename s e2) (rename s e3)
+  rename s (S.Case  l e   as  ) = S.Case l (rename s e) (map (rename s) as)
+  rename s (S.Tuple l bxd es  ) = S.Tuple l bxd (map (rename s) es)
+  rename s (S.List  l es      ) = S.List l (map (rename s) es)
+  rename s (S.Paren l e       ) = S.Paren l (rename s e)
+  rename s (S.ExpTypeSig l e t) = S.ExpTypeSig l (rename s e) t
 
 -- | 'Rename' instance for optionally qualified variable names.
 instance Rename (S.QName a) where
-  rename s qname = case qname of
     -- TODO qualified variables should not be renamed.
-    S.Qual l mname name -> S.Qual l mname (rename s name)
-    S.UnQual  l name    -> S.UnQual l (rename s name)
-    S.Special l special -> S.Special l special
+  rename s (S.Qual l mname name) = S.Qual l mname (rename s name)
+  rename s (S.UnQual  l name   ) = S.UnQual l (rename s name)
+  rename _ (S.Special l special) = S.Special l special
 
 -- | 'Rename' instance for variable names.
 instance Rename (S.Name a) where
-  rename s name = case name of
-    S.Ident  l str -> S.Ident l $ s str
-    S.Symbol l str -> S.Ident l $ s str
+  rename s (S.Ident  l str) = S.Ident l $ s str
+  rename s (S.Symbol l str) = S.Ident l $ s str
 
 -- | 'Rename' instance for @case@ expression alternatives.
 --
@@ -116,24 +118,22 @@ instance Rename (S.Alt s) where
 
 -- | 'Rename' instance for patterns.
 instance Rename (S.Pat a) where
-  rename s pat = case pat of
-    S.PVar l name -> S.PVar l (rename s name)
-    S.PInfixApp l p1 qname p2 ->
-      S.PInfixApp l (rename s p1) (rename s qname) (rename s p2)
-    S.PApp   l qname ps -> S.PApp l (rename s qname) (map (rename s) ps)
-    S.PTuple l boxed ps -> S.PTuple l boxed (map (rename s) ps)
-    S.PList  l ps       -> S.PList l (map (rename s) ps)
-    S.PParen l p        -> S.PParen l (rename s p)
-    S.PWildCard l       -> S.PWildCard l
+  rename s (S.PVar l name) = S.PVar l (rename s name)
+  rename s (S.PInfixApp l p1 qname p2) =
+    S.PInfixApp l (rename s p1) (rename s qname) (rename s p2)
+  rename s (S.PApp   l qname ps) = S.PApp l (rename s qname) (map (rename s) ps)
+  rename s (S.PTuple l boxed ps) = S.PTuple l boxed (map (rename s) ps)
+  rename s (S.PList  l ps      ) = S.PList l (map (rename s) ps)
+  rename s (S.PParen l p       ) = S.PParen l (rename s p)
+  rename _ (S.PWildCard l      ) = S.PWildCard l
 
 -- | 'Rename' instance for right-hand sides.
 --
 --   Applies the substitution to guards and the expression on the right-hand
 --   sides.
 instance Rename (S.Rhs s) where
-  rename s rhs = case rhs of
-    S.UnGuardedRhs l e    -> S.UnGuardedRhs l (rename s e)
-    S.GuardedRhss  l rhss -> S.GuardedRhss l (map (rename s) rhss)
+  rename s (S.UnGuardedRhs l e   ) = S.UnGuardedRhs l (rename s e)
+  rename s (S.GuardedRhss  l rhss) = S.GuardedRhss l (map (rename s) rhss)
 
 -- | 'Rename' instance for right-hand sides with guards.
 instance Rename (S.GuardedRhs s) where

--- a/src/lib/HST/Environment/Renaming.hs
+++ b/src/lib/HST/Environment/Renaming.hs
@@ -43,18 +43,17 @@ instance TermSubst S.Exp where
     S.Lit l literal -> S.Lit l literal
     S.InfixApp l e1 qop e2 ->
       S.InfixApp l (substitute s e1) qop (substitute s e2)
+    S.NegApp l e     -> S.NegApp l (substitute s e)
     S.App    l e1 e2 -> S.App l (substitute s e1) (substitute s e2)
     S.Lambda l ps e  -> S.Lambda l ps (substitute s e)
     S.Let    l b  e  -> S.Let l b $ substitute s e
     S.If l e1 e2 e3 ->
       S.If l (substitute s e1) (substitute s e2) (substitute s e3)
-    S.Case  l e   as   -> S.Case l e (map (substitute s) as)
-    -- TODO no subst for debugging (substitute s e)
+    S.Case  l e   as   -> S.Case l (substitute s e) (map (substitute s) as)
     S.Tuple l bxd es   -> S.Tuple l bxd (map (substitute s) es)
     S.List  l es       -> S.List l (map (substitute s) es)
     S.Paren l e        -> S.Paren l (substitute s e)
     S.ExpTypeSig l e t -> S.ExpTypeSig l (substitute s e) t
-    _                  -> error "TermSubst: Exp caused an error"
 
 -- | 'TermSubst' instance for @case@ expression alternatives.
 --
@@ -68,7 +67,7 @@ instance TermSubst S.Alt where
 --   There must be no guards.
 instance TermSubst S.Rhs where
   substitute s rhs = case rhs of
-    S.UnGuardedRhs l e -> S.UnGuardedRhs l $ substitute s e
+    S.UnGuardedRhs l e -> S.UnGuardedRhs l (substitute s e)
     S.GuardedRhss  _ _ -> error "TermSubst: GuardedRhss not supported"
 
 -- | Type class for AST nodes of type @c@ a 'Subst' can be applied to.
@@ -78,12 +77,12 @@ class Rename c where
 
 -- | 'Rename' instance for expressions.
 instance Rename (S.Exp a) where
-    -- rename :: Subst -> Exp l -> Exp l
   rename s expr = case expr of
     S.Var l qname          -> S.Var l (rename s qname)
     S.Con l qname          -> S.Con l qname
     S.Lit l literal        -> S.Lit l literal
     S.InfixApp l e1 qop e2 -> S.InfixApp l (rename s e1) qop (rename s e2)
+    S.NegApp l e           -> S.NegApp l (rename s e)
     S.App    l e1 e2       -> S.App l (rename s e1) (rename s e2)
     S.Lambda l ps e        -> S.Lambda l (map (rename s) ps) (rename s e)
     S.Let    l b  e        -> S.Let l b $ rename s e
@@ -93,7 +92,6 @@ instance Rename (S.Exp a) where
     S.List  l es           -> S.List l (map (rename s) es)
     S.Paren l e            -> S.Paren l (rename s e)
     S.ExpTypeSig l e t     -> S.ExpTypeSig l (rename s e) t
-    _                      -> error "Rename: Exp caused an error"
 
 -- | 'Rename' instance for optionally qualified variable names.
 instance Rename (S.QName a) where
@@ -119,20 +117,24 @@ instance Rename (S.Alt s) where
 -- | 'Rename' instance for patterns.
 instance Rename (S.Pat a) where
   rename s pat = case pat of
-    S.PVar l name -> S.PVar l $ rename s name
+    S.PVar l name -> S.PVar l (rename s name)
     S.PInfixApp l p1 qname p2 ->
       S.PInfixApp l (rename s p1) (rename s qname) (rename s p2)
     S.PApp   l qname ps -> S.PApp l (rename s qname) (map (rename s) ps)
     S.PTuple l boxed ps -> S.PTuple l boxed (map (rename s) ps)
     S.PList  l ps       -> S.PList l (map (rename s) ps)
-    S.PParen l p        -> S.PParen l $ rename s p
+    S.PParen l p        -> S.PParen l (rename s p)
     S.PWildCard l       -> S.PWildCard l
 
 -- | 'Rename' instance for right-hand sides.
 --
---   Applies the substitution to the expression on the right-hand side.
---   There must be no guards.
+--   Applies the substitution to guards and the expression on the right-hand
+--   sides.
 instance Rename (S.Rhs s) where
   rename s rhs = case rhs of
-    S.UnGuardedRhs l e -> S.UnGuardedRhs l $ rename s e
-    S.GuardedRhss  _ _ -> error "Rename: GuardedRhss not supported"
+    S.UnGuardedRhs l e    -> S.UnGuardedRhs l (rename s e)
+    S.GuardedRhss  l rhss -> S.GuardedRhss l (map (rename s) rhss)
+
+-- | 'Rename' instance for right-hand sides with guards.
+instance Rename (S.GuardedRhs s) where
+  rename s (S.GuardedRhs l e1 e2) = S.GuardedRhs l (rename s e1) (rename s e2)

--- a/src/lib/HST/Environment/Renaming.hs
+++ b/src/lib/HST/Environment/Renaming.hs
@@ -129,8 +129,8 @@ instance Rename (S.Pat a) where
 
 -- | 'Rename' instance for right-hand sides.
 --
---   Applies the substitution to guards and the expression on the right-hand
---   sides.
+--   Applies the substitution to all guards and the expressions of the
+--   right-hand sides.
 instance Rename (S.Rhs s) where
   rename s (S.UnGuardedRhs l e   ) = S.UnGuardedRhs l (rename s e)
   rename s (S.GuardedRhss  l rhss) = S.GuardedRhss l (map (rename s) rhss)

--- a/src/lib/HST/Feature/CaseCompletion.hs
+++ b/src/lib/HST/Feature/CaseCompletion.hs
@@ -7,7 +7,8 @@ module HST.Feature.CaseCompletion
 where
 
 import           Control.Monad                  ( replicateM )
-import           Polysemy                       ( Members
+import           Polysemy                       ( Member
+                                                , Members
                                                 , Sem
                                                 )
 
@@ -21,18 +22,20 @@ import           HST.Effect.Fresh               ( Fresh
                                                 , genericFreshPrefix
                                                 )
 import           HST.Effect.GetOpt              ( GetOpt )
+import           HST.Effect.Report              ( Report )
 import qualified HST.Frontend.Syntax           as S
+import           HST.Util.Selectors             ( fromUnguardedRhs )
 
 -- | Takes a given expression and applies the algorithm on it resulting in
 --   completed cases
 completeCase
-  :: (Members '[Env a, Fresh, GetOpt] r, S.EqAST a)
+  :: (Members '[Env a, Fresh, GetOpt, Report] r, S.EqAST a)
   => Bool
   -> S.Exp a
   -> Sem r (S.Exp a)
 completeCase insideLet (S.Case _ expr as) = do
-  v <- freshVarPat genericFreshPrefix
-  let eqs = map getEqFromAlt as
+  v    <- freshVarPat genericFreshPrefix
+  eqs  <- mapM getEqFromAlt as
   eqs' <- mapM (\(p, ex) -> completeCase insideLet ex >>= \e -> return (p, e))
                eqs
   res <- match [v] eqs' defaultErrorExp
@@ -44,47 +47,60 @@ completeCase insideLet (S.Case _ expr as) = do
       let a = S.alt v res
       return $ S.Case S.NoSrcSpan expr [a]
 completeCase il (S.InfixApp _ e1 qop e2) = do
-  exp1 <- completeCase il e1
-  exp2 <- completeCase il e2
-  return $ S.InfixApp S.NoSrcSpan exp1 qop exp2
+  e1' <- completeCase il e1
+  e2' <- completeCase il e2
+  return $ S.InfixApp S.NoSrcSpan e1' qop e2'
+completeCase il (S.NegApp _ e) = do
+  e' <- completeCase il e
+  return $ S.NegApp S.NoSrcSpan e'
 completeCase il (S.App _ e1 e2) = do
-  exp1 <- completeCase il e1
-  exp2 <- completeCase il e2
-  return $ S.App S.NoSrcSpan exp1 exp2
+  e1' <- completeCase il e1
+  e2' <- completeCase il e2
+  return $ S.App S.NoSrcSpan e1' e2'
 completeCase il (S.Lambda _ ps    e) = completeLambda ps e il
 completeCase il (S.Let    _ binds e) = do
   e'     <- completeCase il e -- undefined -- TODO
   binds' <- completeBindRhs binds
   return $ S.Let S.NoSrcSpan binds' e'
 completeCase il (S.If _ e1 e2 e3) = do
-  exp1 <- completeCase il e1
-  exp2 <- completeCase il e2
-  exp3 <- completeCase il e3
-  return $ S.If S.NoSrcSpan exp1 exp2 exp3
+  e1' <- completeCase il e1
+  e2' <- completeCase il e2
+  e3' <- completeCase il e3
+  return $ S.If S.NoSrcSpan e1' e2' e3'
 completeCase il (S.Tuple _ boxed es) = do
-  exps <- mapM (completeCase il) es  -- complete case für List Expression
-  return $ S.Tuple S.NoSrcSpan boxed exps
-completeCase il (S.Paren _ e1) = do
-  exp1 <- completeCase il e1
-  return $ S.Paren S.NoSrcSpan exp1
-completeCase _ v = return v
--- TODO unhandled or not implemented cons missing. Is NegApp used?
+  es' <- mapM (completeCase il) es  -- complete case für List Expression
+  return $ S.Tuple S.NoSrcSpan boxed es'
+completeCase il (S.List _ es) = do
+  es' <- mapM (completeCase il) es
+  return $ S.List S.NoSrcSpan es'
+completeCase il (S.Paren _ e) = do
+  e' <- completeCase il e
+  return $ S.Paren S.NoSrcSpan e'
+completeCase il (S.ExpTypeSig _ e t) = do
+  e' <- completeCase il e
+  return $ S.ExpTypeSig S.NoSrcSpan e' t
+
+-- Variables, Constructors and literals contain no expressions to complete
+-- pattern matching in.
+completeCase _ e@(S.Var _ _) = return e
+completeCase _ e@(S.Con _ _) = return e
+completeCase _ e@(S.Lit _ _) = return e
 
 completeBindRhs
-  :: (Members '[Env a, Fresh, GetOpt] r, S.EqAST a)
+  :: (Members '[Env a, Fresh, GetOpt, Report] r, S.EqAST a)
   => S.Binds a
   -> Sem r (S.Binds a)
 completeBindRhs (S.BDecls _ decls) = do
   decls' <- mapM (applyCCDecl True) decls
   return $ S.BDecls S.NoSrcSpan decls'
---completeBindRhs _ = error "completeBindRhs: ImplicitBinds not supported yet"
 
-getEqFromAlt :: S.Alt a -> Eqs a
-getEqFromAlt (S.Alt _ pat (S.UnGuardedRhs _ expr) _) = ([pat], expr)
-getEqFromAlt _ = error "guarded Rhs in getEqFromAlt"
+getEqFromAlt :: Member Report r => S.Alt a -> Sem r (Eqs a)
+getEqFromAlt (S.Alt _ pat rhs _) = do
+  expr <- fromUnguardedRhs rhs
+  return ([pat], expr)
 
 completeLambda
-  :: (Members '[Env a, Fresh, GetOpt] r, S.EqAST a)
+  :: (Members '[Env a, Fresh, GetOpt, Report] r, S.EqAST a)
   => [S.Pat a]
   -> S.Exp a
   -> Bool
@@ -97,7 +113,7 @@ completeLambda ps e insideLet = do
   return $ S.Lambda S.NoSrcSpan xs res
 
 applyCCModule
-  :: (Members '[Env a, Fresh, GetOpt] r, S.EqAST a)
+  :: (Members '[Env a, Fresh, GetOpt, Report] r, S.EqAST a)
   => S.Module a
   -> Sem r (S.Module a)
 applyCCModule (S.Module s origModuleHead decls) = do
@@ -105,7 +121,7 @@ applyCCModule (S.Module s origModuleHead decls) = do
   return $ S.Module s origModuleHead decls'
 
 applyCCDecl
-  :: (Members '[Env a, Fresh, GetOpt] r, S.EqAST a)
+  :: (Members '[Env a, Fresh, GetOpt, Report] r, S.EqAST a)
   => Bool
   -> S.Decl a
   -> Sem r (S.Decl a)
@@ -115,7 +131,7 @@ applyCCDecl insideLet (S.FunBind _ ms) = do
 applyCCDecl _ v = return v
 
 applyCCMatches
-  :: (Members '[Env a, Fresh, GetOpt] r, S.EqAST a)
+  :: (Members '[Env a, Fresh, GetOpt, Report] r, S.EqAST a)
   => Bool
   -> [S.Match a]
   -> Sem r [S.Match a]
@@ -123,21 +139,15 @@ applyCCMatches insideLet = mapM applyCCMatch
  where
   -- TODO maybe only apply if needed -> isIncomplete?
   applyCCMatch
-    :: (Members '[Env a, Fresh, GetOpt] r, S.EqAST a)
+    :: (Members '[Env a, Fresh, GetOpt, Report] r, S.EqAST a)
     => S.Match a
     -> Sem r (S.Match a)
-  applyCCMatch (S.Match _ n ps rhs _) = case rhs of
-    S.UnGuardedRhs _ e -> do
-      x <- completeCase insideLet e
-      return $ S.Match S.NoSrcSpan n ps (S.UnGuardedRhs S.NoSrcSpan x) Nothing
-    S.GuardedRhss _ _ -> error "applyCCMatch: GuardedRhs found"
-  applyCCMatch (S.InfixMatch _ p n ps rhs _) = case rhs of
-    S.UnGuardedRhs _ e -> do
-      x <- completeCase insideLet e
-      return $ S.InfixMatch S.NoSrcSpan
-                            p
-                            n
-                            ps
-                            (S.UnGuardedRhs S.NoSrcSpan x)
-                            Nothing
-    S.GuardedRhss _ _ -> error "applyCCMatch: GuardedRhs found"
+  applyCCMatch (S.Match _ n ps rhs _) = do
+    e <- fromUnguardedRhs rhs
+    x <- completeCase insideLet e
+    return $ S.Match S.NoSrcSpan n ps (S.UnGuardedRhs S.NoSrcSpan x) Nothing
+  applyCCMatch (S.InfixMatch _ p n ps rhs _) = do
+    e <- fromUnguardedRhs rhs
+    x <- completeCase insideLet e
+    return
+      $ S.InfixMatch S.NoSrcSpan p n ps (S.UnGuardedRhs S.NoSrcSpan x) Nothing

--- a/src/lib/HST/Feature/CaseCompletion.hs
+++ b/src/lib/HST/Feature/CaseCompletion.hs
@@ -74,9 +74,9 @@ completeBindRhs
   :: (Members '[Env a, Fresh, GetOpt] r, S.EqAST a)
   => S.Binds a
   -> Sem r (S.Binds a)
-completeBindRhs (S.BDecls _ dcls) = do
-  dcls' <- mapM (applyCCDecl True) dcls
-  return $ S.BDecls S.NoSrcSpan dcls'
+completeBindRhs (S.BDecls _ decls) = do
+  decls' <- mapM (applyCCDecl True) decls
+  return $ S.BDecls S.NoSrcSpan decls'
 --completeBindRhs _ = error "completeBindRhs: ImplicitBinds not supported yet"
 
 getEqFromAlt :: S.Alt a -> Eqs a
@@ -100,9 +100,9 @@ applyCCModule
   :: (Members '[Env a, Fresh, GetOpt] r, S.EqAST a)
   => S.Module a
   -> Sem r (S.Module a)
-applyCCModule (S.Module ds) = do
-  dcls <- mapM (applyCCDecl False) ds
-  return $ S.Module dcls
+applyCCModule (S.Module s origModuleHead decls) = do
+  decls' <- mapM (applyCCDecl False) decls
+  return $ S.Module s origModuleHead decls'
 
 applyCCDecl
   :: (Members '[Env a, Fresh, GetOpt] r, S.EqAST a)

--- a/src/lib/HST/Feature/CaseCompletion.hs
+++ b/src/lib/HST/Feature/CaseCompletion.hs
@@ -12,7 +12,7 @@ import           Polysemy                       ( Members
                                                 )
 
 import           HST.CoreAlgorithm              ( match
-                                                , err
+                                                , defaultErrorExp
                                                 , Eqs
                                                 )
 import           HST.Effect.Env                 ( Env )
@@ -35,7 +35,7 @@ completeCase insideLet (S.Case _ expr as) = do
   let eqs = map getEqFromAlt as
   eqs' <- mapM (\(p, ex) -> completeCase insideLet ex >>= \e -> return (p, e))
                eqs
-  res <- match [v] eqs' err
+  res <- match [v] eqs' defaultErrorExp
   if not insideLet
     then do
       let (S.Case _ _ resAs) = res
@@ -93,7 +93,7 @@ completeLambda ps e insideLet = do
   xs <- replicateM (length ps) (freshVarPat genericFreshPrefix)
   e' <- completeCase insideLet e
   let eq = (ps, e')
-  res <- match xs [eq] err
+  res <- match xs [eq] defaultErrorExp
   return $ S.Lambda S.NoSrcSpan xs res
 
 applyCCModule

--- a/src/lib/HST/Feature/CaseCompletion.hs
+++ b/src/lib/HST/Feature/CaseCompletion.hs
@@ -24,7 +24,7 @@ import           HST.Effect.Fresh               ( Fresh
 import           HST.Effect.GetOpt              ( GetOpt )
 import           HST.Effect.Report              ( Report )
 import qualified HST.Frontend.Syntax           as S
-import           HST.Util.Selectors             ( fromUnguardedRhs )
+import           HST.Util.Selectors             ( expFromUnguardedRhs )
 
 -- | Takes a given expression and applies the algorithm on it resulting in
 --   completed cases
@@ -96,7 +96,7 @@ completeBindRhs (S.BDecls _ decls) = do
 
 getEqFromAlt :: Member Report r => S.Alt a -> Sem r (Eqs a)
 getEqFromAlt (S.Alt _ pat rhs _) = do
-  expr <- fromUnguardedRhs rhs
+  expr <- expFromUnguardedRhs rhs
   return ([pat], expr)
 
 completeLambda
@@ -143,11 +143,11 @@ applyCCMatches insideLet = mapM applyCCMatch
     => S.Match a
     -> Sem r (S.Match a)
   applyCCMatch (S.Match _ n ps rhs _) = do
-    e <- fromUnguardedRhs rhs
+    e <- expFromUnguardedRhs rhs
     x <- completeCase insideLet e
     return $ S.Match S.NoSrcSpan n ps (S.UnGuardedRhs S.NoSrcSpan x) Nothing
   applyCCMatch (S.InfixMatch _ p n ps rhs _) = do
-    e <- fromUnguardedRhs rhs
+    e <- expFromUnguardedRhs rhs
     x <- completeCase insideLet e
     return
       $ S.InfixMatch S.NoSrcSpan p n ps (S.UnGuardedRhs S.NoSrcSpan x) Nothing

--- a/src/lib/HST/Feature/GuardElimination.hs
+++ b/src/lib/HST/Feature/GuardElimination.hs
@@ -184,9 +184,9 @@ applyGEAlts alts
 
 -- | Applies guard elimination to function declarations in the given module.
 applyGEModule :: Member Fresh r => S.Module a -> Sem r (S.Module a)
-applyGEModule (S.Module decls) = do
+applyGEModule (S.Module s origModuleHead decls) = do
   decls' <- mapM applyGEDecl decls
-  return $ S.Module decls'
+  return $ S.Module s origModuleHead decls'
 
 -- | Applies guard elimination to a declaration.
 --
@@ -195,8 +195,8 @@ applyGEDecl :: Member Fresh r => S.Decl a -> Sem r (S.Decl a)
 applyGEDecl (S.FunBind _ ms) = do
   ms' <- applyGEMatches ms
   return (S.FunBind S.NoSrcSpan ms')
-applyGEDecl decl@(S.TypeSig  _ _ _) = return decl
-applyGEDecl decl@(S.DataDecl _ _ _) = return decl
+applyGEDecl decl@(S.DataDecl _ _ _ _) = return decl
+applyGEDecl decl@(S.OtherDecl _ _   ) = return decl
 
 -- | Applies guard elimination to the rules of a function declaration.
 --

--- a/src/lib/HST/Feature/GuardElimination.hs
+++ b/src/lib/HST/Feature/GuardElimination.hs
@@ -49,7 +49,7 @@ generateLet
   => [S.Exp a] -- ^ Variables to match.
   -> S.Exp a   -- ^ Expression to use if patterns don't match or the guard is
                --   not satisfied.
-  -> [GExp a]  -- ^ Patters to match and the corrsponding right-hand sides.
+  -> [GExp a]  -- ^ Patterns to match and the corresponding right-hand sides.
   -> Sem r (S.Exp a)
 generateLet vs err gExps = do
   varNames <- replicateM (length gExps + 1) (freshName genericFreshPrefix)
@@ -72,14 +72,14 @@ makeVarBinding name expr = S.FunBind
 -- @case@ Expressions                                                        --
 -------------------------------------------------------------------------------
 
--- | Generates nested case expression for each variable and pattern pair.
+-- | Generates a nested case expression for each variable and pattern pair.
 --
 --   @'generateNestedCases' e f [(x₁, p₁), …, (xₙ, pₙ)]@ produces an expression
 --   of the following form.
 --
 --   > case x₁ of { p₁ -> (… case xₙ of { pₙ -> e ; _ -> f }  …) ; _ -> f }
 generateNestedCases
-  :: S.Exp a              -- ^ Expression to use if all pattern match.
+  :: S.Exp a              -- ^ Expression to use if all patterns match.
   -> S.Exp a              -- ^ Expression to use if any pattern does not match.
   -> [(S.Exp a, S.Pat a)] -- ^ Expression/pattern pairs to match.
   -> S.Exp a
@@ -127,7 +127,7 @@ guardedRhsToIf (S.GuardedRhs _ e1 e2) = S.If S.NoSrcSpan e1 e2
 -- Guard Elimination                                                         --
 -------------------------------------------------------------------------------
 
--- | Applies guard elimination on @case@ expression in the given expression.
+-- | Applies guard elimination on @case@ expressions in the given expression.
 applyGEExp :: Member Fresh r => S.Exp a -> Sem r (S.Exp a)
 applyGEExp (S.InfixApp _ e1 qop e2) = do
   e1' <- applyGEExp e1

--- a/src/lib/HST/Feature/GuardElimination.hs
+++ b/src/lib/HST/Feature/GuardElimination.hs
@@ -59,8 +59,8 @@ generateLet vs err gExps = do
       decls     = zipWith makeVarBinding varNames (caseExprs ++ [err])
   return $ S.Let S.NoSrcSpan (S.BDecls S.NoSrcSpan decls) startVarExpr
 
--- | Creates a function declaration for a @let@ binding of a variable with the
---   given name to the given expression.
+-- | Creates a function declaration for a @let@ binding that binds a variable
+--   with the given name to the given expression.
 makeVarBinding :: S.Name a -> S.Exp a -> S.Decl a
 makeVarBinding name expr = S.FunBind
   S.NoSrcSpan

--- a/src/lib/HST/Feature/GuardElimination.hs
+++ b/src/lib/HST/Feature/GuardElimination.hs
@@ -195,7 +195,8 @@ applyGEDecl :: Member Fresh r => S.Decl a -> Sem r (S.Decl a)
 applyGEDecl (S.FunBind _ ms) = do
   ms' <- applyGEMatches ms
   return (S.FunBind S.NoSrcSpan ms')
-applyGEDecl decl@(S.DataDecl _ _) = return decl
+applyGEDecl decl@(S.TypeSig _ _ _) = return decl
+applyGEDecl decl@(S.DataDecl _ _ ) = return decl
 
 -- | Applies guard elimination to the rules of a function declaration.
 --

--- a/src/lib/HST/Feature/GuardElimination.hs
+++ b/src/lib/HST/Feature/GuardElimination.hs
@@ -259,7 +259,7 @@ hasGuardsExp (S.Tuple _ _  es     ) = any hasGuardsExp es
 hasGuardsExp (S.List  _ es        ) = any hasGuardsExp es
 hasGuardsExp (S.Paren _ e'        ) = hasGuardsExp e'
 hasGuardsExp (S.ExpTypeSig _ e' _ ) = hasGuardsExp e'
-  -- Variables, constructors and literals contain no guards.
+-- Variables, constructors and literals contain no guards.
 hasGuardsExp (S.Var _ _           ) = False
 hasGuardsExp (S.Con _ _           ) = False
 hasGuardsExp (S.Lit _ _           ) = False

--- a/src/lib/HST/Feature/GuardElimination.hs
+++ b/src/lib/HST/Feature/GuardElimination.hs
@@ -11,9 +11,7 @@ import           Polysemy                       ( Member
                                                 , Sem
                                                 )
 
-import           HST.CoreAlgorithm              ( defaultErrorExp
-                                                , translatePVar
-                                                )
+import           HST.CoreAlgorithm              ( defaultErrorExp )
 import           HST.Effect.Fresh               ( Fresh
                                                 , freshName
                                                 , freshVarPat
@@ -178,7 +176,7 @@ applyGEAlts alts
   | any hasGuardsAlt alts = do
     let gexps = map altToGExp alts
     newVar' <- freshVarPat genericFreshPrefix
-    e       <- generateLet [translatePVar newVar'] defaultErrorExp gexps
+    e       <- generateLet [S.patToExp newVar'] defaultErrorExp gexps
     return [S.Alt S.NoSrcSpan newVar' (S.UnGuardedRhs S.NoSrcSpan e) Nothing]
   | otherwise = return alts
 
@@ -216,7 +214,7 @@ applyGE ms = do
       gexps = map matchToGExp ms
       arity = length (gExpPats (head gexps))
   varPats <- replicateM arity (freshVarPat genericFreshPrefix)
-  expr'   <- generateLet (map translatePVar varPats) defaultErrorExp gexps
+  expr'   <- generateLet (map S.patToExp varPats) defaultErrorExp gexps
   return $ S.Match S.NoSrcSpan
                    name
                    varPats

--- a/src/lib/HST/Feature/GuardElimination.hs
+++ b/src/lib/HST/Feature/GuardElimination.hs
@@ -195,8 +195,8 @@ applyGEDecl :: Member Fresh r => S.Decl a -> Sem r (S.Decl a)
 applyGEDecl (S.FunBind _ ms) = do
   ms' <- applyGEMatches ms
   return (S.FunBind S.NoSrcSpan ms')
-applyGEDecl decl@(S.TypeSig _ _ _) = return decl
-applyGEDecl decl@(S.DataDecl _ _ ) = return decl
+applyGEDecl decl@(S.TypeSig  _ _ _) = return decl
+applyGEDecl decl@(S.DataDecl _ _ _) = return decl
 
 -- | Applies guard elimination to the rules of a function declaration.
 --

--- a/src/lib/HST/Feature/Optimization.hs
+++ b/src/lib/HST/Feature/Optimization.hs
@@ -117,6 +117,7 @@ renameAndOpt
   -> [S.Alt a] -- ^ The alternatives of the current @case@ expression.
   -> Sem r (S.Exp a)
 renameAndOpt pat alts =
+  -- TODO we actually need to unify the patterns in this case.
   case find (cheatEq (getQNamePat pat) . getQName) alts of
     Nothing -> reportFatal $ Message Error $ "Found no possible alternative."
     Just (S.Alt _ pat' rhs _) -> do
@@ -183,6 +184,6 @@ addAndOpt v alts = do
 optimizeAlt
   :: Members '[PatternStack a, Fresh, Report] r => S.Alt a -> Sem r (S.Alt a)
 optimizeAlt (S.Alt _ p rhs _) = do
-  let (S.UnGuardedRhs _ e) = rhs
+  e  <- selectExp rhs
   e' <- optimize' e
   return $ S.Alt S.NoSrcSpan p (S.UnGuardedRhs S.NoSrcSpan e') Nothing

--- a/src/lib/HST/Feature/Optimization.hs
+++ b/src/lib/HST/Feature/Optimization.hs
@@ -40,7 +40,7 @@ optimize :: Members '[Fresh, Report] r => S.Exp a -> Sem r (S.Exp a)
 optimize = runPatternStack . optimize'
 
 -- | Like 'optimize' but can access a stack of patterns for each local
---   variable to remember which patterns variables have been matched
+--   variable to remember the patterns that variables have been matched
 --   against.
 optimize'
   :: Members '[PatternStack a, Fresh, Report] r => S.Exp a -> Sem r (S.Exp a)

--- a/src/lib/HST/Frontend/FromHSE.hs
+++ b/src/lib/HST/Frontend/FromHSE.hs
@@ -232,12 +232,12 @@ transformQualConDecl (HSE.QualConDecl _ _ _ conDecl) = transformConDecl conDecl
 --   declaration.
 transformConDecl
   :: Member Report r => HSE.ConDecl HSE.SrcSpanInfo -> Sem r (S.ConDecl HSE)
-transformConDecl (HSE.ConDecl _ cName types) = do
+transformConDecl (HSE.ConDecl s cName types) = do
   name' <- transformName cName
-  return (S.ConDecl name' types)
-transformConDecl (HSE.InfixConDecl _ t1 cName t2) = do
+  return (S.ConDecl (transformSrcSpan s) name' types)
+transformConDecl (HSE.InfixConDecl s t1 cName t2) = do
   name' <- transformName cName
-  return (S.InfixConDecl t1 name' t2)
+  return (S.InfixConDecl (transformSrcSpan s) t1 name' t2)
 transformConDecl (HSE.RecDecl _ _ _) = notSupported "Records"
 
 -- | Transforms an HSE match into an HST match.

--- a/src/lib/HST/Frontend/FromHSE.hs
+++ b/src/lib/HST/Frontend/FromHSE.hs
@@ -7,13 +7,25 @@
 
 module HST.Frontend.FromHSE where
 
-import           Data.Maybe                     ( fromMaybe
-                                                , mapMaybe
+import           Control.Monad.Extra            ( mapMaybeM )
+import qualified Language.Haskell.Exts         as HSE
+import           Polysemy                       ( Member
+                                                , Sem
                                                 )
 
-import qualified Language.Haskell.Exts         as HSE
-
+import           HST.Effect.Report              ( Message(Message)
+                                                , Report
+                                                , Severity(Error, Info)
+                                                , report
+                                                , reportFatal
+                                                )
 import qualified HST.Frontend.Syntax           as S
+
+-------------------------------------------------------------------------------
+-- Type Family Instances                                                     --
+-------------------------------------------------------------------------------
+
+-- TODO Move type family instances to own @HST.Frontend.Syntax.HSE@ module.
 
 -- | Type representing the AST data structure of @haskell-src-exts@.
 --
@@ -29,193 +41,384 @@ type instance S.TypeExp HSE = HSE.Type HSE.SrcSpanInfo
 instance S.EqAST HSE
 instance S.ShowAST HSE
 
+------------------------------------------------------------------------------
+-- Error messages                                                           --
+------------------------------------------------------------------------------
+
+-- | Reports a fatal error that the given feature is not supported.
+notSupported
+  :: Member Report r
+  => String -- ^ The name of the feature (plural) that is not supported.
+  -> Sem r b
+notSupported feature =
+  reportFatal $ Message Error $ feature ++ " are not supported!"
+
+-- | Informs the user that the given feature is not supported and the
+--   corresponding AST node will be skipped.
+skipNotSupported
+  :: Member Report r
+  => String -- ^ The name of the feature (plural) that is not supported.
+  -> Sem r ()
+skipNotSupported feature =
+  report $ Message Info $ feature ++ " are not supported and will be skipped!"
+
+-------------------------------------------------------------------------------
+-- Modules                                                                   --
+-------------------------------------------------------------------------------
+
 -- | Transforms the @haskell-src-exts@ representation of a Haskell module into
 --   the @haskell-src-transformations@ representation of a Haskell module.
-transformModule :: HSE.Module HSE.SrcSpanInfo -> S.Module HSE
+transformModule
+  :: Member Report r => HSE.Module HSE.SrcSpanInfo -> Sem r (S.Module HSE)
 transformModule (HSE.Module _ _ _ _ decls) =
-  S.Module (mapMaybe transformDecl decls)
-transformModule _ = error "Unsupported Module type"
+  S.Module <$> mapMaybeM transformDeclMaybe decls
+transformModule (HSE.XmlPage _ _ _ _ _ _ _      ) = notSupported "XML Modules"
+transformModule (HSE.XmlHybrid _ _ _ _ _ _ _ _ _) = notSupported "XML Modules"
+
+-------------------------------------------------------------------------------
+-- Declarations                                                              --
+-------------------------------------------------------------------------------
 
 -- | Transforms an HSE declaration into an HST declaration.
 --
---   Unlike the other transforming functions, the result is wrapped inside
---   the @Maybe@ type, so instead of an error, @Nothing@ is returned if the
---   HSE declaration cannot be transformed.
-transformDecl :: HSE.Decl HSE.SrcSpanInfo -> Maybe (S.Decl HSE)
-transformDecl (HSE.DataDecl _ (HSE.DataType _) _ dHead qcds _) =
-  Just (S.DataDecl (transformDeclHead dHead) (map transformQualConDecl qcds))
-transformDecl (HSE.TypeSig s names typ) =
-  Just (S.TypeSig (transformSrcSpan s) (map transformName names) typ)
-transformDecl (HSE.FunBind s matches) =
-  Just (S.FunBind (transformSrcSpan s) (map transformMatch matches))
-transformDecl (HSE.PatBind s (HSE.PVar _ name) rhs mBinds) = Just
-  (S.FunBind (transformSrcSpan s)
-             [transformMatch (HSE.Match s name [] rhs mBinds)]
-  )
-transformDecl _ = Nothing
+--   Reports a fatal error if the declaration cannot be transformed.
+transformDecl
+  :: Member Report r => HSE.Decl HSE.SrcSpanInfo -> Sem r (S.Decl HSE)
+transformDecl = transformDecl' return notSupported
+
+-- | Transforms an HSE declaration into an HST declaration.
+--
+--   Return @Nothing@ if the declaration cannot be transformed.
+transformDeclMaybe
+  :: Member Report r => HSE.Decl HSE.SrcSpanInfo -> Sem r (Maybe (S.Decl HSE))
+transformDeclMaybe =
+  transformDecl' (return . Just) (fmap (const Nothing) . skipNotSupported)
+
+-- | Transforms an HSE declaration into an HST declaration uses the given
+--   functions to return results and report errors.
+transformDecl'
+  :: Member Report r
+  => (S.Decl HSE -> Sem r b)  -- ^ Returns the transformed declaration.
+  -> (String -> Sem r b)      -- ^ Reports an unsupported feature.
+  -> HSE.Decl HSE.SrcSpanInfo -- ^ The declaration to transform.
+  -> Sem r b
+
+-- Data type and newtype declarations are supported.
+transformDecl' f _ (HSE.DataDecl s _ _ dHead qcds _) = do
+  dHead' <- transformDeclHead dHead
+  qcds'  <- mapM transformQualConDecl qcds
+  f $ S.DataDecl (transformSrcSpan s) dHead' qcds'
+
+-- Type signatures are supported in order to preserve type signatures
+-- in @let@ expressions.
+transformDecl' f _ (HSE.TypeSig s names typ) = do
+  names' <- mapM transformName names
+  f $ S.TypeSig (transformSrcSpan s) names' typ
+
+-- Function declarations are supported.
+transformDecl' f _ (HSE.FunBind s matches) = do
+  matches' <- mapM transformMatch matches
+  f $ S.FunBind (transformSrcSpan s) matches'
+
+-- Only variable pattern bindings are supported.
+transformDecl' f _ (HSE.PatBind s (HSE.PVar _ name) rhs mBinds) = do
+  match' <- transformMatch (HSE.Match s name [] rhs mBinds)
+  f $ S.FunBind (transformSrcSpan s) [match']
+transformDecl' _ g (HSE.PatBind _ _ _ _) = g "Non-variable pattern bindings"
+
+-- All other declarations are not supported.
+transformDecl' _ g (HSE.TypeDecl _ _ _             ) = g "Type synonyms"
+transformDecl' _ g (HSE.TypeFamDecl _ _ _ _        ) = g "Type families"
+transformDecl' _ g (HSE.ClosedTypeFamDecl _ _ _ _ _) = g "Type families"
+transformDecl' _ g (HSE.GDataDecl _ _ _ _ _ _ _    ) = g "GADTs"
+transformDecl' _ g (HSE.DataFamDecl _ _ _ _        ) = g "Data families"
+transformDecl' _ g (HSE.TypeInsDecl _ _ _          ) = g "Type families"
+transformDecl' _ g (HSE.DataInsDecl _ _ _ _ _      ) = g "Data families"
+transformDecl' _ g (HSE.GDataInsDecl _ _ _ _ _ _) = g "GADTs and type families"
+transformDecl' _ g (HSE.ClassDecl _ _ _ _ _        ) = g "Type classes"
+transformDecl' _ g (HSE.InstDecl _ _ _ _           ) = g "Type classes"
+transformDecl' _ g (HSE.DerivDecl _ _ _ _) =
+  g "Stand-alone deriving declarations"
+transformDecl' _ g (HSE.InfixDecl _ _ _ _      ) = g "Fixity declarations"
+transformDecl' _ g (HSE.DefaultDecl _ _        ) = g "Type classes"
+transformDecl' _ g (HSE.SpliceDecl  _ _        ) = g "Template Haskell"
+transformDecl' _ g (HSE.TSpliceDecl _ _        ) = g "Template Haskell"
+transformDecl' _ g (HSE.PatSynSig _ _ _ _ _ _ _) = g "Pattern synonyms"
+transformDecl' _ g (HSE.PatSyn _ _ _ _         ) = g "Pattern synonyms"
+transformDecl' _ g (HSE.ForImp _ _ _ _ _ _     ) = g "Foreign imports"
+transformDecl' _ g (HSE.ForExp _ _ _ _ _       ) = g "Foreign exports"
+transformDecl' _ g (HSE.RulePragmaDecl _ _     ) = g "RULES pragmas"
+transformDecl' _ g (HSE.DeprPragmaDecl _ _     ) = g "DEPRECATED pragmas"
+transformDecl' _ g (HSE.WarnPragmaDecl _ _     ) = g "WARNING pragmas"
+transformDecl' _ g (HSE.InlineSig _ _ _ _      ) = g "INLINE pragmas"
+transformDecl' _ g (HSE.InlineConlikeSig _ _ _ ) = g "INLINE CONLIKE pragmas"
+transformDecl' _ g (HSE.SpecSig _ _ _ _        ) = g "SPECIALISE pragmas"
+transformDecl' _ g (HSE.SpecInlineSig _ _ _ _ _) =
+  g "SPECIALISE INLINE pragmas"
+transformDecl' _ g (HSE.InstSig       _ _   ) = g "SPECIALISE instance pragmas"
+transformDecl' _ g (HSE.AnnPragma     _ _   ) = g "ANN pragmas"
+transformDecl' _ g (HSE.MinimalPragma _ _   ) = g "MINIMAL pragmas"
+transformDecl' _ g (HSE.RoleAnnotDecl  _ _ _) = g "Role annotations"
+transformDecl' _ g (HSE.CompletePragma _ _ _) = g "COMPLETE pragmas"
 
 -- | Transforms an HSE declaration head into an HST declaration head.
-transformDeclHead :: HSE.DeclHead HSE.SrcSpanInfo -> S.Name HSE
+transformDeclHead :: HSE.DeclHead HSE.SrcSpanInfo -> Sem r (S.Name HSE)
 transformDeclHead (HSE.DHead _ dName    ) = transformName dName
 transformDeclHead (HSE.DHInfix _ _ dName) = transformName dName
 transformDeclHead (HSE.DHParen _ dHead  ) = transformDeclHead dHead
 transformDeclHead (HSE.DHApp _ dHead _  ) = transformDeclHead dHead
 
 -- | Transforms an HSE binding group into an HST binding group.
-transformBinds :: HSE.Binds HSE.SrcSpanInfo -> S.Binds HSE
-transformBinds (HSE.BDecls s decls) = S.BDecls
-  (transformSrcSpan s)
-  (map (fromMaybe (error "Unsupported declaration") . transformDecl) decls)
-transformBinds _ = error "Implicit bindings are not supported"
+transformBinds
+  :: Member Report r => HSE.Binds HSE.SrcSpanInfo -> Sem r (S.Binds HSE)
+transformBinds (HSE.BDecls s decls) = do
+  S.BDecls (transformSrcSpan s) <$> mapM transformDecl decls
+transformBinds (HSE.IPBinds _ _) = notSupported "Implicit-parameters"
 
 -- | Transforms an HSE qualified constructor declaration into an HST
 --   constructor declaration.
-transformQualConDecl :: HSE.QualConDecl HSE.SrcSpanInfo -> S.ConDecl HSE
+transformQualConDecl
+  :: Member Report r => HSE.QualConDecl HSE.SrcSpanInfo -> Sem r (S.ConDecl HSE)
 transformQualConDecl (HSE.QualConDecl _ _ _ conDecl) = transformConDecl conDecl
 
 -- | Transforms an HSE constructor declaration into an HST constructor
 --   declaration.
-transformConDecl :: HSE.ConDecl HSE.SrcSpanInfo -> S.ConDecl HSE
-transformConDecl (HSE.ConDecl _ cName types) =
-  S.ConDecl (transformName cName) types
-transformConDecl (HSE.InfixConDecl _ t1 cName t2) =
-  S.InfixConDecl t1 (transformName cName) t2
-transformConDecl (HSE.RecDecl _ _ _) =
-  error "transformConDecl: record notation is not supported"
+transformConDecl
+  :: Member Report r => HSE.ConDecl HSE.SrcSpanInfo -> Sem r (S.ConDecl HSE)
+transformConDecl (HSE.ConDecl _ cName types) = do
+  name' <- transformName cName
+  return (S.ConDecl name' types)
+transformConDecl (HSE.InfixConDecl _ t1 cName t2) = do
+  name' <- transformName cName
+  return (S.InfixConDecl t1 name' t2)
+transformConDecl (HSE.RecDecl _ _ _) = notSupported "Records"
 
 -- | Transforms an HSE match into an HST match.
-transformMatch :: HSE.Match HSE.SrcSpanInfo -> S.Match HSE
-transformMatch (HSE.Match s name pats rhs mBinds) = S.Match
-  (transformSrcSpan s)
-  (transformName name)
-  (map transformPat pats)
-  (transformRhs rhs)
-  (fmap transformBinds mBinds)
-transformMatch (HSE.InfixMatch s pat name pats rhs mBinds) = S.InfixMatch
-  (transformSrcSpan s)
-  (transformPat pat)
-  (transformName name)
-  (map transformPat pats)
-  (transformRhs rhs)
-  (fmap transformBinds mBinds)
+transformMatch
+  :: Member Report r => HSE.Match HSE.SrcSpanInfo -> Sem r (S.Match HSE)
+transformMatch (HSE.Match s name pats rhs mBinds) =
+  S.Match (transformSrcSpan s)
+    <$> transformName name
+    <*> mapM transformPat pats
+    <*> transformRhs rhs
+    <*> mapM transformBinds mBinds
+transformMatch (HSE.InfixMatch s pat name pats rhs mBinds) =
+  S.InfixMatch (transformSrcSpan s)
+    <$> transformPat pat
+    <*> transformName name
+    <*> mapM transformPat pats
+    <*> transformRhs rhs
+    <*> mapM transformBinds mBinds
 
 -- | Transforms an HSE right hand side into an HST right hand side.
-transformRhs :: HSE.Rhs HSE.SrcSpanInfo -> S.Rhs HSE
+transformRhs :: Member Report r => HSE.Rhs HSE.SrcSpanInfo -> Sem r (S.Rhs HSE)
 transformRhs (HSE.UnGuardedRhs s e) =
-  S.UnGuardedRhs (transformSrcSpan s) (transformExp e)
+  S.UnGuardedRhs (transformSrcSpan s) <$> transformExp e
 transformRhs (HSE.GuardedRhss s grhss) =
-  S.GuardedRhss (transformSrcSpan s) (map transformGuardedRhs grhss)
+  S.GuardedRhss (transformSrcSpan s) <$> mapM transformGuardedRhs grhss
 
 -- | Transforms an HSE guarded right hand side into an HST guarded right hand
 --   side.
-transformGuardedRhs :: HSE.GuardedRhs HSE.SrcSpanInfo -> S.GuardedRhs HSE
+transformGuardedRhs
+  :: Member Report r
+  => HSE.GuardedRhs HSE.SrcSpanInfo
+  -> Sem r (S.GuardedRhs HSE)
 transformGuardedRhs (HSE.GuardedRhs s [HSE.Qualifier _ ge] e) =
-  S.GuardedRhs (transformSrcSpan s) (transformExp ge) (transformExp e)
-transformGuardedRhs _ =
-  error "Only boolean expressions are supported as statements"
+  S.GuardedRhs (transformSrcSpan s) <$> transformExp ge <*> transformExp e
+transformGuardedRhs (HSE.GuardedRhs _ _ _) = notSupported "Pattern guards"
+
+-------------------------------------------------------------------------------
+-- Expressions                                                               --
+-------------------------------------------------------------------------------
 
 -- | Transforms an HSE boxed mark into an HST boxed mark.
-transformBoxed :: HSE.Boxed -> S.Boxed
-transformBoxed HSE.Boxed   = S.Boxed
-transformBoxed HSE.Unboxed = S.Unboxed
+transformBoxed :: HSE.Boxed -> Sem r S.Boxed
+transformBoxed HSE.Boxed   = return S.Boxed
+transformBoxed HSE.Unboxed = return S.Unboxed
 
 -- | Transforms an HSE expression into an HST expression.
-transformExp :: HSE.Exp HSE.SrcSpanInfo -> S.Exp HSE
+transformExp :: Member Report r => HSE.Exp HSE.SrcSpanInfo -> Sem r (S.Exp HSE)
 transformExp (HSE.Var s qName) =
-  S.Var (transformSrcSpan s) (transformQName qName)
+  S.Var (transformSrcSpan s) <$> transformQName qName
 transformExp (HSE.Con s qName) =
-  S.Con (transformSrcSpan s) (transformQName qName)
-transformExp (HSE.Lit s lit           ) = S.Lit (transformSrcSpan s) lit
-transformExp (HSE.InfixApp s e1 qOp e2) = S.InfixApp (transformSrcSpan s)
-                                                     (transformExp e1)
-                                                     (transformQOp qOp)
-                                                     (transformExp e2)
+  S.Con (transformSrcSpan s) <$> transformQName qName
+transformExp (HSE.Lit s lit) = return (S.Lit (transformSrcSpan s) lit)
+transformExp (HSE.InfixApp s e1 qOp e2) =
+  S.InfixApp (transformSrcSpan s)
+    <$> transformExp e1
+    <*> transformQOp qOp
+    <*> transformExp e2
 transformExp (HSE.App s e1 e2) =
-  S.App (transformSrcSpan s) (transformExp e1) (transformExp e2)
-transformExp (HSE.NegApp s e) = S.NegApp (transformSrcSpan s) (transformExp e)
+  S.App (transformSrcSpan s) <$> transformExp e1 <*> transformExp e2
+transformExp (HSE.NegApp s e) =
+  S.NegApp (transformSrcSpan s) <$> transformExp e
 transformExp (HSE.Lambda s pats e) =
-  S.Lambda (transformSrcSpan s) (map transformPat pats) (transformExp e)
+  S.Lambda (transformSrcSpan s) <$> mapM transformPat pats <*> transformExp e
 transformExp (HSE.Let s binds e) =
-  S.Let (transformSrcSpan s) (transformBinds binds) (transformExp e)
-transformExp (HSE.If s e1 e2 e3) = S.If (transformSrcSpan s)
-                                        (transformExp e1)
-                                        (transformExp e2)
-                                        (transformExp e3)
+  S.Let (transformSrcSpan s) <$> transformBinds binds <*> transformExp e
+transformExp (HSE.If s e1 e2 e3) =
+  S.If (transformSrcSpan s)
+    <$> transformExp e1
+    <*> transformExp e2
+    <*> transformExp e3
 transformExp (HSE.Case s e alts) =
-  S.Case (transformSrcSpan s) (transformExp e) (map transformAlt alts)
+  S.Case (transformSrcSpan s) <$> transformExp e <*> mapM transformAlt alts
 transformExp (HSE.Tuple s bxd es) =
-  S.Tuple (transformSrcSpan s) (transformBoxed bxd) (map transformExp es)
+  S.Tuple (transformSrcSpan s) <$> transformBoxed bxd <*> mapM transformExp es
 transformExp (HSE.List s es) =
-  S.List (transformSrcSpan s) (map transformExp es)
-transformExp (HSE.Paren s e) = S.Paren (transformSrcSpan s) (transformExp e)
+  S.List (transformSrcSpan s) <$> mapM transformExp es
+transformExp (HSE.Paren s e) = S.Paren (transformSrcSpan s) <$> transformExp e
 transformExp (HSE.ExpTypeSig s e typ) =
-  S.ExpTypeSig (transformSrcSpan s) (transformExp e) typ
-transformExp _ = error "Unsupported Expression type"
+  S.ExpTypeSig (transformSrcSpan s) <$> transformExp e <*> return typ
+
+-- All other expressions are not supported.
+transformExp (HSE.OverloadedLabel _ _       ) = notSupported "Overloaded labels"
+transformExp (HSE.IPVar _ _) = notSupported "Implicit-parameters"
+transformExp (HSE.MultiIf _ _) = notSupported "Multi-Way if-expressions"
+transformExp (HSE.Do              _ _       ) = notSupported "do-expressions"
+transformExp (HSE.MDo             _ _       ) = notSupported "mdo-expressions"
+transformExp (HSE.UnboxedSum _ _ _ _        ) = notSupported "Unboxed sums"
+transformExp (HSE.TupleSection _ _ _        ) = notSupported "Tuple sections"
+transformExp (HSE.ParArray _ _              ) = notSupported "Parallel arrays"
+transformExp (HSE.LeftSection  _ _ _        ) = notSupported "Sections"
+transformExp (HSE.RightSection _ _ _        ) = notSupported "Sections"
+transformExp (HSE.RecConstr    _ _ _        ) = notSupported "Records"
+transformExp (HSE.RecUpdate    _ _ _        ) = notSupported "Records"
+transformExp (HSE.EnumFrom _ _              ) = notSupported "Enumerations"
+transformExp (HSE.EnumFromTo   _ _ _        ) = notSupported "Enumerations"
+transformExp (HSE.EnumFromThen _ _ _        ) = notSupported "Enumerations"
+transformExp (HSE.EnumFromThenTo _ _ _ _    ) = notSupported "Enumerations"
+transformExp (HSE.ParArrayFromTo _ _ _      ) = notSupported "Parallel arrays"
+transformExp (HSE.ParArrayFromThenTo _ _ _ _) = notSupported "Parallel arrays"
+transformExp (HSE.ListComp _ _ _) = notSupported "List comprehensions"
+transformExp (HSE.ParComp _ _ _) = notSupported "List comprehensions"
+transformExp (HSE.ParArrayComp _ _ _        ) = notSupported "Parallel arrays"
+transformExp (HSE.VarQuote   _ _            ) = notSupported "Template Haskell"
+transformExp (HSE.TypQuote   _ _            ) = notSupported "Template Haskell"
+transformExp (HSE.BracketExp _ _            ) = notSupported "Template Haskell"
+transformExp (HSE.SpliceExp  _ _            ) = notSupported "Template Haskell"
+transformExp (HSE.QuasiQuote _ _ _          ) = notSupported "Template Haskell"
+transformExp (HSE.TypeApp _ _) = notSupported "Visible type applications"
+transformExp (HSE.XTag _ _ _ _ _            ) = notSupported "XML expressions"
+transformExp (HSE.XETag _ _ _ _             ) = notSupported "XML expressions"
+transformExp (HSE.XPcdata   _ _             ) = notSupported "XML expressions"
+transformExp (HSE.XExpTag   _ _             ) = notSupported "XML expressions"
+transformExp (HSE.XChildTag _ _             ) = notSupported "XML expressions"
+transformExp (HSE.CorePragma _ _ _          ) = notSupported "CORE pragmas"
+transformExp (HSE.SCCPragma  _ _ _          ) = notSupported "SCC pragmas"
+transformExp (HSE.GenPragma _ _ _ _ _       ) = notSupported "GENERATED pragmas"
+transformExp (HSE.Proc            _ _ _     ) = notSupported "Arrow expressions"
+transformExp (HSE.LeftArrApp      _ _ _     ) = notSupported "Arrow expressions"
+transformExp (HSE.RightArrApp     _ _ _     ) = notSupported "Arrow expressions"
+transformExp (HSE.LeftArrHighApp  _ _ _     ) = notSupported "Arrow expressions"
+transformExp (HSE.RightArrHighApp _ _ _     ) = notSupported "Arrow expressions"
+transformExp (HSE.ArrOp _ _                 ) = notSupported "Arrow expressions"
+transformExp (HSE.LCase _ _) = notSupported "Lambda case expressions"
 
 -- | Transforms an HSE case alternative into an HST case alternative.
-transformAlt :: HSE.Alt HSE.SrcSpanInfo -> S.Alt HSE
-transformAlt (HSE.Alt s pat rhs mBinds) = S.Alt (transformSrcSpan s)
-                                                (transformPat pat)
-                                                (transformRhs rhs)
-                                                (fmap transformBinds mBinds)
+transformAlt :: Member Report r => HSE.Alt HSE.SrcSpanInfo -> Sem r (S.Alt HSE)
+transformAlt (HSE.Alt s pat rhs mBinds) =
+  S.Alt (transformSrcSpan s)
+    <$> transformPat pat
+    <*> transformRhs rhs
+    <*> mapM transformBinds mBinds
+
+-------------------------------------------------------------------------------
+-- Patterns                                                                  --
+-------------------------------------------------------------------------------
 
 -- | Transforms an HSE pattern into an HST pattern.
-transformPat :: HSE.Pat HSE.SrcSpanInfo -> S.Pat HSE
+transformPat :: Member Report r => HSE.Pat HSE.SrcSpanInfo -> Sem r (S.Pat HSE)
 transformPat (HSE.PVar s name) =
-  S.PVar (transformSrcSpan s) (transformName name)
-transformPat (HSE.PInfixApp s pat1 qName pat2) = S.PInfixApp
-  (transformSrcSpan s)
-  (transformPat pat1)
-  (transformQName qName)
-  (transformPat pat2)
+  S.PVar (transformSrcSpan s) <$> transformName name
+transformPat (HSE.PInfixApp s pat1 qName pat2) =
+  S.PInfixApp (transformSrcSpan s)
+    <$> transformPat pat1
+    <*> transformQName qName
+    <*> transformPat pat2
 transformPat (HSE.PApp s qName pats) =
-  S.PApp (transformSrcSpan s) (transformQName qName) (map transformPat pats)
+  S.PApp (transformSrcSpan s)
+    <$> transformQName qName
+    <*> mapM transformPat pats
 transformPat (HSE.PTuple s bxd pats) =
-  S.PTuple (transformSrcSpan s) (transformBoxed bxd) (map transformPat pats)
+  S.PTuple (transformSrcSpan s)
+    <$> transformBoxed bxd
+    <*> mapM transformPat pats
 transformPat (HSE.PParen s pat) =
-  S.PParen (transformSrcSpan s) (transformPat pat)
+  S.PParen (transformSrcSpan s) <$> transformPat pat
 transformPat (HSE.PList s pats) =
-  S.PList (transformSrcSpan s) (map transformPat pats)
-transformPat (HSE.PWildCard s) = S.PWildCard (transformSrcSpan s)
-transformPat _                 = error "Unsupported Pattern type"
+  S.PList (transformSrcSpan s) <$> mapM transformPat pats
+transformPat (HSE.PWildCard s) = return (S.PWildCard (transformSrcSpan s))
+
+-- All other patterns are not supported.
+transformPat (HSE.PLit    _ _ _      ) = notSupported "Literal patterns"
+transformPat (HSE.PNPlusK _ _ _      ) = notSupported "n+k patterns"
+transformPat (HSE.PUnboxedSum _ _ _ _) = notSupported "Unboxed sums"
+transformPat (HSE.PRec   _ _ _       ) = notSupported "Records"
+transformPat (HSE.PAsPat _ _ _       ) = notSupported "as-patterns"
+transformPat (HSE.PIrrPat _ _        ) = notSupported "Irrefutable patterns"
+transformPat (HSE.PatTypeSig _ _ _) =
+  notSupported "Patterns with type signatures"
+transformPat (HSE.PViewPat _ _ _   ) = notSupported "View patterns"
+transformPat (HSE.PRPat _ _        ) = notSupported "Regular patterns"
+transformPat (HSE.PXTag _ _ _ _ _  ) = notSupported "XML patterns"
+transformPat (HSE.PXETag _ _ _ _   ) = notSupported "XML patterns"
+transformPat (HSE.PXPcdata _ _     ) = notSupported "XML patterns"
+transformPat (HSE.PXPatTag _ _     ) = notSupported "XML patterns"
+transformPat (HSE.PXRPats  _ _     ) = notSupported "XML patterns"
+transformPat (HSE.PSplice  _ _     ) = notSupported "Template Haskell"
+transformPat (HSE.PQuasiQuote _ _ _) = notSupported "Template Haskell"
+transformPat (HSE.PBangPat _ _     ) = notSupported "Bang patterns"
+
+-------------------------------------------------------------------------------
+-- Names                                                                     --
+-------------------------------------------------------------------------------
 
 -- | Transforms an HSE module name into an HST module name.
-transformModuleName :: HSE.ModuleName HSE.SrcSpanInfo -> S.ModuleName HSE
+transformModuleName
+  :: HSE.ModuleName HSE.SrcSpanInfo -> Sem r (S.ModuleName HSE)
 transformModuleName (HSE.ModuleName s name) =
-  S.ModuleName (transformSrcSpan s) name
+  return $ S.ModuleName (transformSrcSpan s) name
 
 -- | Transforms an HSE qualified name into an HST qualified name.
-transformQName :: HSE.QName HSE.SrcSpanInfo -> S.QName HSE
+transformQName :: HSE.QName HSE.SrcSpanInfo -> Sem r (S.QName HSE)
 transformQName (HSE.Qual s modName name) =
-  S.Qual (transformSrcSpan s) (transformModuleName modName) (transformName name)
+  S.Qual (transformSrcSpan s)
+    <$> transformModuleName modName
+    <*> transformName name
 transformQName (HSE.UnQual s name) =
-  S.UnQual (transformSrcSpan s) (transformName name)
+  S.UnQual (transformSrcSpan s) <$> transformName name
 transformQName (HSE.Special s spCon) =
-  S.Special (transformSrcSpan s) (transformSpecialCon spCon)
+  S.Special (transformSrcSpan s) <$> transformSpecialCon spCon
 
 -- | Transforms an HSE name into an HST name.
-transformName :: HSE.Name HSE.SrcSpanInfo -> S.Name HSE
-transformName (HSE.Ident  s name) = S.Ident (transformSrcSpan s) name
-transformName (HSE.Symbol s name) = S.Symbol (transformSrcSpan s) name
+transformName :: HSE.Name HSE.SrcSpanInfo -> Sem r (S.Name HSE)
+transformName (HSE.Ident  s name) = return $ S.Ident (transformSrcSpan s) name
+transformName (HSE.Symbol s name) = return $ S.Symbol (transformSrcSpan s) name
 
 -- | Transforms an HSE qualified operator into an HST qualified operator.
-transformQOp :: HSE.QOp HSE.SrcSpanInfo -> S.QOp HSE
+transformQOp :: HSE.QOp HSE.SrcSpanInfo -> Sem r (S.QOp HSE)
 transformQOp (HSE.QVarOp s qName) =
-  S.QVarOp (transformSrcSpan s) (transformQName qName)
+  S.QVarOp (transformSrcSpan s) <$> transformQName qName
 transformQOp (HSE.QConOp s qName) =
-  S.QConOp (transformSrcSpan s) (transformQName qName)
+  S.QConOp (transformSrcSpan s) <$> transformQName qName
 
 -- | Transforms an HSE special constructor into an HST special constructor.
-transformSpecialCon :: HSE.SpecialCon HSE.SrcSpanInfo -> S.SpecialCon HSE
-transformSpecialCon (HSE.UnitCon s) = S.UnitCon (transformSrcSpan s)
-transformSpecialCon (HSE.ListCon s) = S.ListCon (transformSrcSpan s)
-transformSpecialCon (HSE.FunCon  s) = S.FunCon (transformSrcSpan s)
+transformSpecialCon
+  :: HSE.SpecialCon HSE.SrcSpanInfo -> Sem r (S.SpecialCon HSE)
+transformSpecialCon (HSE.UnitCon s) = return $ S.UnitCon (transformSrcSpan s)
+transformSpecialCon (HSE.ListCon s) = return $ S.ListCon (transformSrcSpan s)
+transformSpecialCon (HSE.FunCon  s) = return $ S.FunCon (transformSrcSpan s)
 transformSpecialCon (HSE.TupleCon s bxd n) =
-  S.TupleCon (transformSrcSpan s) (transformBoxed bxd) n
-transformSpecialCon (HSE.Cons s) = S.Cons (transformSrcSpan s)
+  S.TupleCon (transformSrcSpan s) <$> transformBoxed bxd <*> return n
+transformSpecialCon (HSE.Cons s) = return $ S.Cons (transformSrcSpan s)
 transformSpecialCon (HSE.UnboxedSingleCon s) =
-  S.UnboxedSingleCon (transformSrcSpan s)
-transformSpecialCon (HSE.ExprHole s) = S.ExprHole (transformSrcSpan s)
+  return $ S.UnboxedSingleCon (transformSrcSpan s)
+transformSpecialCon (HSE.ExprHole s) = return $ S.ExprHole (transformSrcSpan s)
+
+-------------------------------------------------------------------------------
+-- Source Spans                                                              --
+-------------------------------------------------------------------------------
 
 -- | Wraps an HSE source span into the HST type for source spans.
 transformSrcSpan :: HSE.SrcSpanInfo -> S.SrcSpan HSE

--- a/src/lib/HST/Frontend/FromHSE.hs
+++ b/src/lib/HST/Frontend/FromHSE.hs
@@ -226,7 +226,7 @@ transformDeclHead (HSE.DHApp _ dHead _  ) = transformDeclHead dHead
 -- | Transforms an HSE binding group into an HST binding group.
 transformBinds
   :: Member Report r => HSE.Binds HSE.SrcSpanInfo -> Sem r (S.Binds HSE)
-transformBinds (HSE.BDecls s decls) = do
+transformBinds (HSE.BDecls s decls) =
   S.BDecls (transformSrcSpan s) <$> mapM transformDecl decls
 transformBinds (HSE.IPBinds _ _) = notSupported "Implicit-parameters"
 

--- a/src/lib/HST/Frontend/FromHSE.hs
+++ b/src/lib/HST/Frontend/FromHSE.hs
@@ -123,7 +123,7 @@ transformDecl decl@(HSE.PatBind s _ _ _) = do
   skipNotSupported "Non-variable pattern bindings"
   return $ S.OtherDecl (transformSrcSpan s) decl
 
--- Type classes and type class instances ar enot supported. The user is
+-- Type classes and type class instances are not supported. The user is
 -- explicitly informed that the declaration is skipped since they might
 -- contain pattern matching.
 transformDecl decl@(HSE.ClassDecl s _ _ _ _) = do
@@ -133,7 +133,7 @@ transformDecl decl@(HSE.InstDecl s _ _ _) = do
   skipNotSupported "Type class instances"
   return $ S.OtherDecl (transformSrcSpan s) decl
 
--- GADTs and pattern synonyms are not supported. The user us explicitly
+-- GADTs and pattern synonyms are not supported. The user is explicitly
 -- informed that the declaration is skipped since there may be errors due
 -- to the skipped constructor or pattern declarations.
 transformDecl decl@(HSE.GDataDecl s _ _ _ _ _ _) = do

--- a/src/lib/HST/Frontend/Syntax.hs
+++ b/src/lib/HST/Frontend/Syntax.hs
@@ -268,7 +268,7 @@ instance HasSrcSpan Pat where
   getSrcSpan (PList  srcSpan _       ) = srcSpan
   getSrcSpan (PWildCard srcSpan      ) = srcSpan
 
--- | Converts a pattern to an expressions.
+-- | Converts a pattern to an expression.
 patToExp :: Pat a -> Exp a
 patToExp (PVar srcSpan name) = Var srcSpan (unQual name)
 patToExp (PInfixApp srcSpan p1 name p2) =

--- a/src/lib/HST/Frontend/Syntax.hs
+++ b/src/lib/HST/Frontend/Syntax.hs
@@ -62,8 +62,9 @@ class ( Show (SrcSpanType a)
 
 -- | A representation of a Haskell module.
 --
---   The pattern matching compiler only needs to know the declarations of
---   the module. All other information is stored in the 'OriginalModuleHead'.
+--   The pattern matching compiler only needs to know the declarations and the
+--   name of the module. All other information is stored in the
+--   'OriginalModuleHead'.
 data Module a
   = Module (SrcSpan a) (OriginalModuleHead a) (Maybe (ModuleName a)) [Decl a]
 deriving instance EqAST a => Eq (Module a)
@@ -114,8 +115,11 @@ instance HasSrcSpan Decl where
 -- Data Type Declarations                                                    --
 -------------------------------------------------------------------------------
 
--- | A data constructor. Does not include a source span and should not be
---   transformed back.
+-- | A data constructor.
+--
+--   Data constructors should not be converted back. The original
+--   constructor declaration should be part of the 'OriginalDecl'
+--   of a 'DataDecl'.
 data ConDecl a = ConDecl (SrcSpan a) (Name a) [TypeExp a]
                | InfixConDecl (SrcSpan a) (TypeExp a) (Name a) (TypeExp a)
 deriving instance EqAST a => Eq (ConDecl a)

--- a/src/lib/HST/Frontend/Syntax.hs
+++ b/src/lib/HST/Frontend/Syntax.hs
@@ -117,9 +117,8 @@ instance HasSrcSpan Decl where
 
 -- | A data constructor.
 --
---   Data constructors should not be converted back. The original
---   constructor declaration should be part of the 'OriginalDecl'
---   of a 'DataDecl'.
+--   Data constructors should not be converted back. The original constructor
+--   declaration should be part of the 'OriginalDecl' of a 'DataDecl'.
 data ConDecl a = ConDecl (SrcSpan a) (Name a) [TypeExp a]
                | InfixConDecl (SrcSpan a) (TypeExp a) (Name a) (TypeExp a)
 deriving instance EqAST a => Eq (ConDecl a)

--- a/src/lib/HST/Frontend/Syntax.hs
+++ b/src/lib/HST/Frontend/Syntax.hs
@@ -66,7 +66,7 @@ deriving instance ShowAST a => Show (Module a)
 --
 --   The only supported kind of pattern bindings, variable patterns, are
 --   represented by function bindings.
-data Decl a = DataDecl (Name a) [ConDecl a]
+data Decl a = DataDecl (SrcSpan a) (Name a) [ConDecl a]
             | TypeSig (SrcSpan a) [Name a] (TypeExp a)
             | FunBind (SrcSpan a) [Match a]
 deriving instance EqAST a => Eq (Decl a)

--- a/src/lib/HST/Frontend/Syntax.hs
+++ b/src/lib/HST/Frontend/Syntax.hs
@@ -68,6 +68,10 @@ data Module a = Module (SrcSpan a) (OriginalModuleHead a) [Decl a]
 deriving instance EqAST a => Eq (Module a)
 deriving instance ShowAST a => Show (Module a)
 
+-- | Gets the source span information of a module.
+instance HasSrcSpan Module where
+  getSrcSpan (Module srcSpan _ _) = srcSpan
+
 -------------------------------------------------------------------------------
 -- Declarations                                                              --
 -------------------------------------------------------------------------------
@@ -99,16 +103,27 @@ data Decl a
 deriving instance EqAST a => Eq (Decl a)
 deriving instance ShowAST a => Show (Decl a)
 
+-- | Gets the source span information of a declaration.
+instance HasSrcSpan Decl where
+  getSrcSpan (DataDecl srcSpan _ _ _) = srcSpan
+  getSrcSpan (FunBind   srcSpan _   ) = srcSpan
+  getSrcSpan (OtherDecl srcSpan _   ) = srcSpan
+
 -------------------------------------------------------------------------------
 -- Data Type Declarations                                                    --
 -------------------------------------------------------------------------------
 
 -- | A data constructor. Does not include a source span and should not be
 --   transformed back.
-data ConDecl a = ConDecl (Name a) [TypeExp a]
-               | InfixConDecl (TypeExp a) (Name a) (TypeExp a)
+data ConDecl a = ConDecl (SrcSpan a) (Name a) [TypeExp a]
+               | InfixConDecl (SrcSpan a) (TypeExp a) (Name a) (TypeExp a)
 deriving instance EqAST a => Eq (ConDecl a)
 deriving instance ShowAST a => Show (ConDecl a)
+
+-- | Gets the source span information of a constructor declaration.
+instance HasSrcSpan ConDecl where
+  getSrcSpan (ConDecl srcSpan _ _       ) = srcSpan
+  getSrcSpan (InfixConDecl srcSpan _ _ _) = srcSpan
 
 -------------------------------------------------------------------------------
 -- Function Declarations                                                     --
@@ -119,6 +134,10 @@ data Binds a = BDecls (SrcSpan a) [Decl a]
 deriving instance EqAST a => Eq (Binds a)
 deriving instance ShowAST a => Show (Binds a)
 
+-- | Gets the source span information of a binding group.
+instance HasSrcSpan Binds where
+  getSrcSpan (BDecls srcSpan _) = srcSpan
+
 -- | A match belonging to a function binding declaration.
 data Match a
   = Match (SrcSpan a) (Name a) [Pat a] (Rhs a) (Maybe (Binds a))
@@ -126,16 +145,30 @@ data Match a
 deriving instance EqAST a => Eq (Match a)
 deriving instance ShowAST a => Show (Match a)
 
+-- | Gets the source span information of a match of a function declaration.
+instance HasSrcSpan Match where
+  getSrcSpan (Match srcSpan _ _ _ _       ) = srcSpan
+  getSrcSpan (InfixMatch srcSpan _ _ _ _ _) = srcSpan
+
 -- | A right hand side belonging to a 'Match'.
 data Rhs a = UnGuardedRhs (SrcSpan a) (Exp a)
            | GuardedRhss (SrcSpan a) [GuardedRhs a]
 deriving instance EqAST a => Eq (Rhs a)
 deriving instance ShowAST a => Show (Rhs a)
 
+-- | Gets the source span information of a right-hand side.
+instance HasSrcSpan Rhs where
+  getSrcSpan (UnGuardedRhs srcSpan _) = srcSpan
+  getSrcSpan (GuardedRhss  srcSpan _) = srcSpan
+
 -- | A guarded right hand side. Only @Bool@ expressions can be used as guards.
 data GuardedRhs a = GuardedRhs (SrcSpan a) (Exp a) (Exp a)
 deriving instance EqAST a => Eq (GuardedRhs a)
 deriving instance ShowAST a => Show (GuardedRhs a)
+
+-- | Gets the source span information of a right-hand side with guard.
+instance HasSrcSpan GuardedRhs where
+  getSrcSpan (GuardedRhs srcSpan _ _) = srcSpan
 
 -------------------------------------------------------------------------------
 -- Expressions                                                               --
@@ -165,22 +198,49 @@ data Exp a = Var (SrcSpan a) (QName a)
 deriving instance EqAST a => Eq (Exp a)
 deriving instance ShowAST a => Show (Exp a)
 
--- | Creates a variable expression from a name. The additional source span
---   information is taken from the given name.
-var :: Name a -> Exp a
-var n@(Ident  s _) = Var s (UnQual s n)
-var n@(Symbol s _) = Var s (UnQual s n)
+-- | Returns the top-level source span information of an expression.
+instance HasSrcSpan Exp where
+  getSrcSpan (Var srcSpan _         ) = srcSpan
+  getSrcSpan (Con srcSpan _         ) = srcSpan
+  getSrcSpan (Lit srcSpan _         ) = srcSpan
+  getSrcSpan (InfixApp srcSpan _ _ _) = srcSpan
+  getSrcSpan (App srcSpan _ _       ) = srcSpan
+  getSrcSpan (NegApp srcSpan _      ) = srcSpan
+  getSrcSpan (Lambda srcSpan _ _    ) = srcSpan
+  getSrcSpan (Let    srcSpan _ _    ) = srcSpan
+  getSrcSpan (If srcSpan _ _ _      ) = srcSpan
+  getSrcSpan (Case  srcSpan _ _     ) = srcSpan
+  getSrcSpan (Tuple srcSpan _ _     ) = srcSpan
+  getSrcSpan (List  srcSpan _       ) = srcSpan
+  getSrcSpan (Paren srcSpan _       ) = srcSpan
+  getSrcSpan (ExpTypeSig srcSpan _ _) = srcSpan
+
+-- | Creates a variable expression from a name.
+--
+--   The additional source span information is taken from the given name.
+var :: (HasSrcSpan name, QNameLike name) => name a -> Exp a
+var name = Var (getSrcSpan name) (toQName name)
+
+-- | Creates a constructor expression from a name.
+--
+--   The additional source span information is taken from the given name.
+con :: (HasSrcSpan name, QNameLike name) => name a -> Exp a
+con name = Con (getSrcSpan name) (toQName name)
 
 -- | An alternative in a @case@ expression.
 data Alt a = Alt (SrcSpan a) (Pat a) (Rhs a) (Maybe (Binds a))
 deriving instance EqAST a => Eq (Alt a)
 deriving instance ShowAST a => Show (Alt a)
 
+-- | Gets the source span information of an alternative.
+instance HasSrcSpan Alt where
+  getSrcSpan (Alt srcSpan _ _ _) = srcSpan
+
 -- | Creates an alternative in a @case@ expression from a pattern and an
 --   expression. The additional source span information is taken from the given
 --   pattern and expression.
 alt :: Pat a -> Exp a -> Alt a
-alt pat e = Alt (getSrcPat pat) pat (UnGuardedRhs (getSrcExp e) e) Nothing
+alt pat e = Alt (getSrcSpan pat) pat (UnGuardedRhs (getSrcSpan e) e) Nothing
 
 -------------------------------------------------------------------------------
 -- Patterns                                                                  --
@@ -197,14 +257,45 @@ data Pat a = PVar (SrcSpan a) (Name a)
   deriving Eq
 deriving instance ShowAST a => Show (Pat a)
 
+-- | Returns the top-level source span information of a pattern.
+instance HasSrcSpan Pat where
+  getSrcSpan (PVar srcSpan _         ) = srcSpan
+  getSrcSpan (PInfixApp srcSpan _ _ _) = srcSpan
+  getSrcSpan (PApp   srcSpan _ _     ) = srcSpan
+  getSrcSpan (PTuple srcSpan _ _     ) = srcSpan
+  getSrcSpan (PParen srcSpan _       ) = srcSpan
+  getSrcSpan (PList  srcSpan _       ) = srcSpan
+  getSrcSpan (PWildCard srcSpan      ) = srcSpan
+
+-- | Converts a pattern to an expressions.
+patToExp :: Pat a -> Exp a
+patToExp (PVar srcSpan name) = Var srcSpan (unQual name)
+patToExp (PInfixApp srcSpan p1 name p2) =
+  InfixApp srcSpan (patToExp p1) (qConOp name) (patToExp p2)
+patToExp (PApp srcSpan name ps) =
+  foldl (App srcSpan) (con name) (map patToExp ps)
+patToExp (PTuple srcSpan boxed ps) = Tuple srcSpan boxed (map patToExp ps)
+patToExp (PParen srcSpan p       ) = Paren srcSpan (patToExp p)
+patToExp (PList  srcSpan ps      ) = List srcSpan (map patToExp ps)
+patToExp (PWildCard srcSpan) = Var srcSpan (Special srcSpan (ExprHole srcSpan))
+
 -------------------------------------------------------------------------------
 -- Names                                                                     --
 -------------------------------------------------------------------------------
+
+-- | Type class for AST nodes that can be used in smart constructors where
+--   'QName's are expected.
+class QNameLike name where
+  toQName :: name a -> QName a
 
 -- | A name of a Haskell module used in a qualified name.
 data ModuleName a = ModuleName (SrcSpan a) String
   deriving (Eq, Ord)
 deriving instance ShowAST a => Show (ModuleName a)
+
+-- | Gets the source span information of a module name.
+instance HasSrcSpan ModuleName where
+  getSrcSpan (ModuleName srcSpan _) = srcSpan
 
 -- | A name possibly qualified by a 'ModuleName'.
 data QName a = Qual (SrcSpan a) (ModuleName a) (Name a)
@@ -213,17 +304,68 @@ data QName a = Qual (SrcSpan a) (ModuleName a) (Name a)
   deriving (Eq, Ord)
 deriving instance ShowAST a => Show (QName a)
 
+-- | Wraps a name with 'UnQual'.
+--
+--   The additional source span information is taken from the given name.
+unQual :: Name a -> QName a
+unQual name = UnQual (getSrcSpan name) name
+
+-- | Wraps a name with 'Special'.
+--
+--   The additional source span information is taken from the given name.
+special :: SpecialCon a -> QName a
+special specialCon = Special (getSrcSpan specialCon) specialCon
+
+-- | Gets the source span information of a possibly qualified name.
+instance HasSrcSpan QName where
+  getSrcSpan (Qual srcSpan _ _ ) = srcSpan
+  getSrcSpan (UnQual  srcSpan _) = srcSpan
+  getSrcSpan (Special srcSpan _) = srcSpan
+
+-- | 'QName's can be used everywhere where 'QName's are expected.
+instance QNameLike QName where
+  toQName = id
+
 -- | An unqualified name.
 data Name a = Ident (SrcSpan a) String
             | Symbol (SrcSpan a) String
   deriving (Eq, Ord)
 deriving instance ShowAST a => Show (Name a)
 
+-- | Gets the source span information of a name.
+instance HasSrcSpan Name where
+  getSrcSpan (Ident  srcSpan _) = srcSpan
+  getSrcSpan (Symbol srcSpan _) = srcSpan
+
+-- | 'Name's can be used everywhere where 'QName's are expected by
+--    wrapping them with 'UnQual'.
+--
+--    The source span information of the 'Name' is copied to the 'QName'.
+instance QNameLike Name where
+  toQName = unQual
+
 -- | A possibly qualified infix operator.
 data QOp a = QVarOp (SrcSpan a) (QName a)
            | QConOp (SrcSpan a) (QName a)
   deriving (Eq, Ord)
 deriving instance ShowAST a => Show (QOp a)
+
+-- | Creates a variable infix operator from a name.
+--
+--   The additional source span information is taken from the given name.
+qVarOp :: (HasSrcSpan name, QNameLike name) => name a -> QOp a
+qVarOp name = QVarOp (getSrcSpan name) (toQName name)
+
+-- | Creates a constructor infix operator from a name.
+--
+--   The additional source span information is taken from the given name.
+qConOp :: (HasSrcSpan name, QNameLike name) => name a -> QOp a
+qConOp name = QConOp (getSrcSpan name) (toQName name)
+
+-- | Gets the source span information of a possibly qualified infix operator.
+instance HasSrcSpan QOp where
+  getSrcSpan (QVarOp srcSpan _) = srcSpan
+  getSrcSpan (QConOp srcSpan _) = srcSpan
 
 -- | A built-in constructor with special syntax.
 data SpecialCon a = UnitCon (SrcSpan a)
@@ -236,9 +378,31 @@ data SpecialCon a = UnitCon (SrcSpan a)
   deriving (Eq, Ord)
 deriving instance ShowAST a => Show (SpecialCon a)
 
+-- | Gets the source span information of a built-in constructor with special
+--   syntax.
+instance HasSrcSpan SpecialCon where
+  getSrcSpan (UnitCon srcSpan         ) = srcSpan
+  getSrcSpan (ListCon srcSpan         ) = srcSpan
+  getSrcSpan (FunCon  srcSpan         ) = srcSpan
+  getSrcSpan (TupleCon srcSpan _ _    ) = srcSpan
+  getSrcSpan (Cons             srcSpan) = srcSpan
+  getSrcSpan (UnboxedSingleCon srcSpan) = srcSpan
+  getSrcSpan (ExprHole         srcSpan) = srcSpan
+
+-- | 'SpecialCon'structors can be used everywhere where 'QName's are expected
+--    by wrapping them with 'Special'.
+--
+--    The source span information of the 'SpecialCon' is copied to the 'QName'.
+instance QNameLike SpecialCon where
+  toQName = special
+
 -------------------------------------------------------------------------------
 -- Source Spans                                                              --
 -------------------------------------------------------------------------------
+
+-- | Type class for AST nodes with a 'SrcSpan'.
+class HasSrcSpan node where
+  getSrcSpan :: node a -> SrcSpan a
 
 -- | A wrapper for source span information with the option to not specify a
 --   source span.
@@ -253,30 +417,3 @@ instance Eq (SrcSpan a) where
 -- | Custom order for 'SrcSpan' which treats all source spans as equal.
 instance Ord (SrcSpan a) where
   _ `compare` _ = EQ
-
--- | Returns the top-level source span information of an expression.
-getSrcExp :: Exp a -> SrcSpan a
-getSrcExp (Var src _         ) = src
-getSrcExp (Con src _         ) = src
-getSrcExp (Lit src _         ) = src
-getSrcExp (InfixApp src _ _ _) = src
-getSrcExp (App src _ _       ) = src
-getSrcExp (NegApp src _      ) = src
-getSrcExp (Lambda src _ _    ) = src
-getSrcExp (Let    src _ _    ) = src
-getSrcExp (If src _ _ _      ) = src
-getSrcExp (Case  src _ _     ) = src
-getSrcExp (Tuple src _ _     ) = src
-getSrcExp (List  src _       ) = src
-getSrcExp (Paren src _       ) = src
-getSrcExp (ExpTypeSig src _ _) = src
-
--- | Returns the top-level source span information of a pattern.
-getSrcPat :: Pat a -> SrcSpan a
-getSrcPat (PVar src _         ) = src
-getSrcPat (PInfixApp src _ _ _) = src
-getSrcPat (PApp   src _ _     ) = src
-getSrcPat (PTuple src _ _     ) = src
-getSrcPat (PParen src _       ) = src
-getSrcPat (PList  src _       ) = src
-getSrcPat (PWildCard src      ) = src

--- a/src/lib/HST/Frontend/ToHSE.hs
+++ b/src/lib/HST/Frontend/ToHSE.hs
@@ -85,7 +85,7 @@ transformRhs (S.GuardedRhss s grhss) =
 transformGuardedRhs :: S.GuardedRhs HSE -> HSE.GuardedRhs HSE.SrcSpanInfo
 transformGuardedRhs (S.GuardedRhs s ge e) = HSE.GuardedRhs
   (transformSrcSpan s)
-  [HSE.Qualifier (transformSrcSpan (S.getSrcExp ge)) (transformExp ge)]
+  [HSE.Qualifier (transformSrcSpan (S.getSrcSpan ge)) (transformExp ge)]
   (transformExp e)
 
 -- | Transforms an HST boxed mark into an HSE boxed mark.

--- a/src/lib/HST/Frontend/ToHSE.hs
+++ b/src/lib/HST/Frontend/ToHSE.hs
@@ -40,7 +40,7 @@ transformModule _ _ = error "Unsupported Module type"
 
 -- | Transforms an HST declaration into an HSE declaration.
 transformDecl :: S.Decl HSE -> HSE.Decl HSE.SrcSpanInfo
-transformDecl (S.DataDecl _ _) =
+transformDecl (S.DataDecl _ _ _) =
   error "Data type declarations should not be transformed back"
 transformDecl (S.TypeSig s names typ) =
   HSE.TypeSig (transformSrcSpan s) (map transformName names) typ

--- a/src/lib/HST/Frontend/ToHSE.hs
+++ b/src/lib/HST/Frontend/ToHSE.hs
@@ -29,7 +29,7 @@ import           HST.Frontend.FromHSE           ( HSE
 --   module into the @haskell-src-exts@ representation of a Haskell module.
 --
 --   The module head is restored from the original module head. The module
---   name field does not affect the name of the resulting module..
+--   name field does not affect the name of the resulting module.
 transformModule :: S.Module HSE -> HSE.Module HSE.SrcSpanInfo
 transformModule (S.Module s origModuleHead _ decls) = HSE.Module
   (transformSrcSpan s)

--- a/src/lib/HST/Frontend/ToHSE.hs
+++ b/src/lib/HST/Frontend/ToHSE.hs
@@ -13,39 +13,44 @@ module HST.Frontend.ToHSE where
 import qualified Language.Haskell.Exts         as HSE
 
 import qualified HST.Frontend.Syntax           as S
-import           HST.Frontend.FromHSE           ( HSE )
+import           HST.Frontend.FromHSE           ( HSE
+                                                , OriginalModuleHead
+                                                  ( originalModuleHead
+                                                  , originalModulePragmas
+                                                  , originalModuleImports
+                                                  )
+                                                )
+
+-------------------------------------------------------------------------------
+-- Modules                                                                   --
+-------------------------------------------------------------------------------
 
 -- | Transforms the @haskell-src-transformations@ representation of a Haskell
 --   module into the @haskell-src-exts@ representation of a Haskell module by
 --   enriching it with information from the original HSE module.
-transformModule
-  :: HSE.Module HSE.SrcSpanInfo -> S.Module HSE -> HSE.Module HSE.SrcSpanInfo
-transformModule (HSE.Module srcS mmh pragmas impDecls oDecls) (S.Module aDecls)
-  = HSE.Module
-    srcS
-    mmh
-    pragmas
-    impDecls
-    (combineDecls oDecls (map transformDecl (filter isFun aDecls)))
- where
-  isFun (S.FunBind _ _) = True
-  isFun _               = False
-  combineDecls (HSE.FunBind _ _ : oDecls') (aDecl : aDecls') =
-    aDecl : combineDecls oDecls' aDecls'
-  combineDecls (HSE.PatBind _ _ _ _ : oDecls') (aDecl : aDecls') =
-    aDecl : combineDecls oDecls' aDecls'
-  combineDecls (oDecl : oDecls') aDecls' = oDecl : combineDecls oDecls' aDecls'
-  combineDecls []                aDecls' = aDecls'
-transformModule _ _ = error "Unsupported Module type"
+transformModule :: S.Module HSE -> HSE.Module HSE.SrcSpanInfo
+transformModule (S.Module s origModuleHead decls) = HSE.Module
+  (transformSrcSpan s)
+  (originalModuleHead origModuleHead)
+  (originalModulePragmas origModuleHead)
+  (originalModuleImports origModuleHead)
+  (map transformDecl decls)
+
+-------------------------------------------------------------------------------
+-- Declarations                                                              --
+-------------------------------------------------------------------------------
 
 -- | Transforms an HST declaration into an HSE declaration.
+--
+--   Only function declarations are actually transformed from the
+--   intermediate representation to @HSE@. All other declarations
+--   (including data type declarations) are restored from the
+--   original declaration stored in the AST.
 transformDecl :: S.Decl HSE -> HSE.Decl HSE.SrcSpanInfo
-transformDecl (S.DataDecl _ _ _) =
-  error "Data type declarations should not be transformed back"
-transformDecl (S.TypeSig s names typ) =
-  HSE.TypeSig (transformSrcSpan s) (map transformName names) typ
 transformDecl (S.FunBind s matches) =
   HSE.FunBind (transformSrcSpan s) (map transformMatch matches)
+transformDecl (S.DataDecl _ originalDecl _ _) = originalDecl
+transformDecl (S.OtherDecl _ originalDecl   ) = originalDecl
 
 -- | Transforms an HST binding group into an HSE binding group.
 transformBinds :: S.Binds HSE -> HSE.Binds HSE.SrcSpanInfo
@@ -88,6 +93,10 @@ transformBoxed :: S.Boxed -> HSE.Boxed
 transformBoxed S.Boxed   = HSE.Boxed
 transformBoxed S.Unboxed = HSE.Unboxed
 
+-------------------------------------------------------------------------------
+-- Expressions                                                               --
+-------------------------------------------------------------------------------
+
 -- | Transforms an HST expression into an HSE expression.
 transformExp :: S.Exp HSE -> HSE.Exp HSE.SrcSpanInfo
 transformExp (S.Var s qName) =
@@ -127,6 +136,10 @@ transformAlt (S.Alt s pat rhs mBinds) = HSE.Alt (transformSrcSpan s)
                                                 (transformRhs rhs)
                                                 (fmap transformBinds mBinds)
 
+-------------------------------------------------------------------------------
+-- Patterns                                                                  --
+-------------------------------------------------------------------------------
+
 -- | Transforms an HST pattern into an HSE pattern.
 transformPat :: S.Pat HSE -> HSE.Pat HSE.SrcSpanInfo
 transformPat (S.PVar s name) =
@@ -145,6 +158,10 @@ transformPat (S.PParen s pat) =
 transformPat (S.PList s pats) =
   HSE.PList (transformSrcSpan s) (map transformPat pats)
 transformPat (S.PWildCard s) = HSE.PWildCard (transformSrcSpan s)
+
+-------------------------------------------------------------------------------
+-- Names                                                                     --
+-------------------------------------------------------------------------------
 
 -- | Transforms an HST module name into an HSE module name.
 transformModuleName :: S.ModuleName HSE -> HSE.ModuleName HSE.SrcSpanInfo
@@ -185,6 +202,10 @@ transformSpecialCon (S.Cons s) = HSE.Cons (transformSrcSpan s)
 transformSpecialCon (S.UnboxedSingleCon s) =
   HSE.UnboxedSingleCon (transformSrcSpan s)
 transformSpecialCon (S.ExprHole s) = HSE.ExprHole (transformSrcSpan s)
+
+-------------------------------------------------------------------------------
+-- Source Spans                                                              --
+-------------------------------------------------------------------------------
 
 -- | Unwraps the HST type for source spans into an HSE source span.
 transformSrcSpan :: S.SrcSpan HSE -> HSE.SrcSpanInfo

--- a/src/lib/HST/Options.hs
+++ b/src/lib/HST/Options.hs
@@ -51,7 +51,8 @@ ghclibFrontendName = "ghc-lib"
 -- | Map that maps strings to the corresponding front ends. Used for parsing
 --   the front end option.
 frontendMap :: Map String Frontend
-frontendMap = Map.fromList [(hseFrontendName, HSE), (ghclibFrontendName, GHClib)]
+frontendMap =
+  Map.fromList [(hseFrontendName, HSE), (ghclibFrontendName, GHClib)]
 
 -- | Parses a given string to one of the front ends.
 parseFrontend :: Member Report r => String -> Sem r Frontend

--- a/src/lib/HST/Util/Predicates.hs
+++ b/src/lib/HST/Util/Predicates.hs
@@ -1,0 +1,37 @@
+-- | This module contains commonly used predicate functions for AST nodes.
+
+module HST.Util.Predicates
+  ( -- * Pattern Predicates
+    isConPat
+  , isVarPat
+  )
+where
+
+import qualified HST.Frontend.Syntax           as S
+
+-- | Tests whether the given pattern is a constructor pattern.
+--
+--   Special patterns for lists and tuples are also considered constructor
+--   patterns.
+isConPat :: S.Pat a -> Bool
+isConPat (S.PApp _ _ _       ) = True
+isConPat (S.PInfixApp _ _ _ _) = True
+isConPat (S.PList _ _        ) = True
+isConPat (S.PTuple _ _ _     ) = True
+isConPat (S.PParen _ p       ) = isConPat p
+
+  -- All other patterns are variable patterns.
+isConPat (S.PVar   _ _       ) = False
+isConPat (S.PWildCard _      ) = False
+
+-- | Tests whether the given pattern is a variable or wildcard pattern.
+isVarPat :: S.Pat a -> Bool
+isVarPat (S.PVar _ _         ) = True
+isVarPat (S.PWildCard _      ) = True
+isVarPat (S.PParen _ p       ) = isVarPat p
+
+-- All other patterns are not variable patterns.
+isVarPat (S.PApp _ _ _       ) = False
+isVarPat (S.PInfixApp _ _ _ _) = False
+isVarPat (S.PList _ _        ) = False
+isVarPat (S.PTuple _ _ _     ) = False

--- a/src/lib/HST/Util/PrettyName.hs
+++ b/src/lib/HST/Util/PrettyName.hs
@@ -30,8 +30,8 @@ instance PrettyName (S.Name a) where
 -- | Helper functions for 'PrettyName' instance of 'S.Name' and 'S.QName'
 --   that pretty prints a name but adds a prefix.
 --
---    The prefix is added before the identifier or symbol. In case of symbolic
---    names, the prefix is within the parentheses.
+--   The prefix is added before the identifier or symbol. In case of symbolic
+--   names, the prefix is within the parentheses.
 prettyNameWithPrefix :: String -> S.Name a -> String
 prettyNameWithPrefix prefix (S.Ident  _ ident) = prefix ++ ident
 prettyNameWithPrefix prefix (S.Symbol _ sym  ) = "(" ++ prefix ++ sym ++ ")"

--- a/src/lib/HST/Util/PrettyName.hs
+++ b/src/lib/HST/Util/PrettyName.hs
@@ -1,0 +1,57 @@
+-- | This module contains functions for pretty printing names of the
+--   intermediate representation for error messages.
+
+module HST.Util.PrettyName
+  ( PrettyName(prettyName)
+  )
+where
+
+import qualified HST.Frontend.Syntax           as S
+
+-- | Type class for name AST nodes that can be pretty printed.
+class PrettyName a where
+  prettyName :: a -> String
+
+-- | Pretty prints a module name.
+instance PrettyName (S.ModuleName a) where
+  prettyName (S.ModuleName _ modName) = modName
+
+-- | Pretty prints a possibly qualified name.
+instance PrettyName (S.QName a) where
+  prettyName (S.Qual _ modName name) =
+    prettyNameWithPrefix (prettyName modName ++ ".") name
+  prettyName (S.UnQual  _ name      ) = prettyName name
+  prettyName (S.Special _ specialCon) = prettyName specialCon
+
+-- | Pretty prints a name.
+instance PrettyName (S.Name a) where
+  prettyName = prettyNameWithPrefix ""
+
+-- | Helper functions for 'PrettyName' instance of 'S.Name' and 'S.QName'
+--   that pretty prints a name but adds a prefix.
+--
+--    The prefix is added before the identifier or symbol. In case of symbolic
+--    names, the prefix is within the parentheses.
+prettyNameWithPrefix :: String -> S.Name a -> String
+prettyNameWithPrefix prefix (S.Ident  _ ident) = prefix ++ ident
+prettyNameWithPrefix prefix (S.Symbol _ sym  ) = "(" ++ prefix ++ sym ++ ")"
+
+-- | Pretty prints a possibly qualified infix operator.
+instance PrettyName (S.QOp a) where
+  prettyName (S.QVarOp _ name) = prettyName name
+  prettyName (S.QConOp _ name) = prettyName name
+
+-- | Pretty prints the name of a special constructor.
+instance PrettyName (S.SpecialCon a) where
+  prettyName (S.UnitCon _) = "()"
+  prettyName (S.ListCon _) = "[]"
+  prettyName (S.FunCon  _) = "(->)"
+  prettyName (S.TupleCon _ boxed n) =
+    "(" ++ prettyBoxed ++ replicate n ',' ++ prettyBoxed ++ ")"
+   where
+    prettyBoxed = case boxed of
+      S.Boxed   -> ""
+      S.Unboxed -> "#"
+  prettyName (S.Cons             _) = "(:)"
+  prettyName (S.UnboxedSingleCon _) = "(# #)"
+  prettyName (S.ExprHole         _) = "_"

--- a/src/lib/HST/Util/Selectors.hs
+++ b/src/lib/HST/Util/Selectors.hs
@@ -1,21 +1,115 @@
 -- | This module contains commonly used getter functions that report fatal
 --   internal errors if an AST node does not match.
 
-module HST.Util.Selectors where
+module HST.Util.Selectors
+  ( -- * Right-hand sides
+    expFromUnguardedRhs
+    -- * Pattern Names
+  , getAltConName
+  , getPatConName
+  , getMaybePatConName
+  , getPatVarName
+  )
+where
 
 import           Polysemy                       ( Member
+                                                , Members
                                                 , Sem
+                                                , run
                                                 )
 
+import           HST.Effect.Fresh               ( Fresh
+                                                , freshIdent
+                                                , genericFreshPrefix
+                                                )
 import           HST.Effect.Report              ( Message(..)
                                                 , Report
-                                                , Severity(Internal)
+                                                , Severity(Error, Internal)
+                                                , evalReport
                                                 , reportFatal
                                                 )
 import qualified HST.Frontend.Syntax           as S
 
+-------------------------------------------------------------------------------
+-- Right-hand sides                                                          --
+-------------------------------------------------------------------------------
+
 -- | Gets the expressions of the given right-hand side of a rule.
-fromUnguardedRhs :: Member Report r => S.Rhs a -> Sem r (S.Exp a)
-fromUnguardedRhs (S.UnGuardedRhs _ expr) = return expr
-fromUnguardedRhs (S.GuardedRhss _ _) =
-  reportFatal $ Message Internal "Expected unguarded right-hand side."
+expFromUnguardedRhs :: Member Report r => S.Rhs a -> Sem r (S.Exp a)
+expFromUnguardedRhs (S.UnGuardedRhs _ expr) = return expr
+expFromUnguardedRhs (S.GuardedRhss _ _) =
+  reportFatal $ Message Internal $ "Expected unguarded right-hand side."
+
+-------------------------------------------------------------------------------
+-- Pattern Names                                                             --
+-------------------------------------------------------------------------------
+
+-- | Gets the name of the outermost constructor matched by the given @case@
+--   expression alternative.
+getAltConName :: Member Report r => S.Alt a -> Sem r (S.QName a)
+getAltConName (S.Alt _ p _ _) = getPatConName p
+
+-- | Gets the name of the outermost constructor matched by the given pattern.
+--
+--   Reports a fatal error if the given pattern is not a constructor pattern.
+getPatConName :: Member Report r => S.Pat a -> Sem r (S.QName a)
+getPatConName (S.PApp _ conName _       ) = return conName
+getPatConName (S.PInfixApp _ _ conName _) = return conName
+
+-- Constructor patterns with special syntax.
+getPatConName (S.PList _ pats)
+  | null pats = return $ S.Special S.NoSrcSpan (S.ListCon S.NoSrcSpan)
+  | otherwise = return $ S.Special S.NoSrcSpan (S.Cons S.NoSrcSpan)
+getPatConName (S.PTuple _ boxed pats) =
+  return $ S.Special S.NoSrcSpan (S.TupleCon S.NoSrcSpan boxed (length pats))
+
+-- Look into parentheses recursively.
+getPatConName (S.PParen _ pat) = getPatConName pat
+
+-- All other patterns are not constructor patterns.
+getPatConName (S.PVar _ _) =
+  reportFatal
+    $ Message Error
+    $ "Expected constructor pattern, got variable pattern."
+getPatConName (S.PWildCard _) =
+  reportFatal
+    $ Message Error
+    $ "Expected constructor pattern, got wildcard pattern."
+
+-- | Like 'getPatConName' but returns @Nothing@ if the given pattern is not
+--   a variable pattern.
+getMaybePatConName :: S.Pat a -> Maybe (S.QName a)
+getMaybePatConName = run . evalReport . getPatConName
+
+-- | Extracts the name of the variable bound by the given variable pattern.
+--
+--   Returns a fresh variable for wildcard patterns.
+--   The given pattern must be a variable or wildcard pattern. Otherwise a
+--   fatal internal error is reported.
+getPatVarName :: Members '[Fresh, Report] r => S.Pat a -> Sem r String
+getPatVarName (S.PVar _ pname) = return (getNameStr pname)
+ where
+  getNameStr (S.Ident  _ str) = str
+  getNameStr (S.Symbol _ str) = str
+getPatVarName (S.PWildCard _ ) = freshIdent genericFreshPrefix
+
+-- Look into parentheses recursively.
+getPatVarName (S.PParen _ pat) = getPatVarName pat
+
+-- All other patterns are not variable patterns.
+getPatVarName (S.PApp _ _ _) =
+  reportFatal
+    $ Message Error
+    $ "Expected variable or wildcard pattern, got constructor pattern."
+getPatVarName (S.PInfixApp _ _ _ _) =
+  reportFatal
+    $ Message Error
+    $ "Expected variable or wildcard pattern, got infix constructor pattern."
+getPatVarName (S.PTuple _ _ _) =
+  reportFatal
+    $ Message Error
+    $ "Expected variable or wildcard pattern, got tuple pattern."
+getPatVarName (S.PList _ _) =
+  reportFatal
+    $ Message Error
+    $ "Expected variable or wildcard pattern, got list pattern."

--- a/src/lib/HST/Util/Selectors.hs
+++ b/src/lib/HST/Util/Selectors.hs
@@ -1,0 +1,21 @@
+-- | This module contains commonly used getter functions that report fatal
+--   internal errors if an AST node does not match.
+
+module HST.Util.Selectors where
+
+import           Polysemy                       ( Member
+                                                , Sem
+                                                )
+
+import           HST.Effect.Report              ( Message(..)
+                                                , Report
+                                                , Severity(Internal)
+                                                , reportFatal
+                                                )
+import qualified HST.Frontend.Syntax           as S
+
+-- | Gets the expressions of the given right-hand side of a rule.
+fromUnguardedRhs :: Member Report r => S.Rhs a -> Sem r (S.Exp a)
+fromUnguardedRhs (S.UnGuardedRhs _ expr) = return expr
+fromUnguardedRhs (S.GuardedRhss _ _) =
+  reportFatal $ Message Internal "Expected unguarded right-hand side."

--- a/src/lib/HST/Util/Selectors.hs
+++ b/src/lib/HST/Util/Selectors.hs
@@ -34,7 +34,9 @@ import qualified HST.Frontend.Syntax           as S
 -- Right-hand sides                                                          --
 -------------------------------------------------------------------------------
 
--- | Gets the expressions of the given right-hand side of a rule.
+-- | Gets the expression of the given unguarded right-hand side of a rule.
+--
+--   Reports a fatal internal error if the given right-hand side has a guard.
 expFromUnguardedRhs :: Member Report r => S.Rhs a -> Sem r (S.Exp a)
 expFromUnguardedRhs (S.UnGuardedRhs _ expr) = return expr
 expFromUnguardedRhs (S.GuardedRhss _ _) =

--- a/src/test/HST/ApplicationTests.hs
+++ b/src/test/HST/ApplicationTests.hs
@@ -117,7 +117,7 @@ testProcessModule = context "processModule" $ do
       ]
     mod2' <- runTest (processModule (FromHSE.transformModule mod1))
     let mod2 = ToHSE.transformModule mod1 mod2'
-    expected `prettyShouldBe` mod2
+    mod2 `prettyShouldBe` expected
   it "should transform pattern matching in a partial function" $ do
     mod1 <- parseTestModule
       $ unlines ["module A where", "head :: [a] -> a", "head (x:xs) = x"]

--- a/src/test/HST/ApplicationTests.hs
+++ b/src/test/HST/ApplicationTests.hs
@@ -6,7 +6,6 @@ where
 
 import           Polysemy                       ( Member
                                                 , Sem
-                                                , raiseUnder
                                                 , runM
                                                 )
 import           Polysemy.Embed                 ( Embed
@@ -60,9 +59,8 @@ parseTestModule modStr = case parseModule modStr of
 
 -- | Runs the given computation with an empty environment and no additional
 --   command line arguments.
-runTest :: Sem '[Env a, Fresh, GetOpt, Embed IO] b -> IO b
-runTest =
-  runM . reportToExpectation . runWithArgs [] . raiseUnder . runFresh . runEnv
+runTest :: Sem '[Env a, Fresh, GetOpt, Report, Embed IO] b -> IO b
+runTest = runM . reportToExpectation . runWithArgs [] . runFresh . runEnv
 
 -------------------------------------------------------------------------------
 -- Expectation Setters                                                       --

--- a/src/test/HST/ApplicationTests.hs
+++ b/src/test/HST/ApplicationTests.hs
@@ -143,7 +143,7 @@ testProcessModule = context "processModule" $ do
       , "              a3 -> if otherwise then a3"
       , "                                 else a2"
       , "            a2 = undefined"
-      , "         in a1"
+      , "        in a1"
       ]
     mod2 `prettyShouldBe` expected
   it "should accept a more complex guarded function" $ do

--- a/src/test/HST/ApplicationTests.hs
+++ b/src/test/HST/ApplicationTests.hs
@@ -139,10 +139,10 @@ testProcessModule = context "processModule" $ do
     expected <- parseTestModule $ unlines
       [ "module A where"
       , "id :: a -> a"
-      , "id a0 = let a2 = undefined"
-      , "            a1 = case a0 of"
+      , "id a0 = let a1 = case a0 of"
       , "              a3 -> if otherwise then a3"
       , "                                 else a2"
+      , "            a2 = undefined"
       , "         in a1"
       ]
     mod2 `prettyShouldBe` expected
@@ -159,13 +159,13 @@ testProcessModule = context "processModule" $ do
       [ "module A where"
       , "useless :: (a -> Bool) -> a -> a -> a"
       , "useless a0 a1 a2 ="
-      , "  let a4 = undefined"
-      , "      a3 = case a0 of"
+      , "  let a3 = case a0 of"
       , "        a5 -> case a1 of"
       , "          a6 -> case a2 of"
       , "            a7 -> if a5 a6 then a6"
       , "                           else if otherwise then a7"
       , "                                             else a4"
+      , "      a4 = undefined"
       , "  in a3"
       ]
     mod2 `prettyShouldBe` expected

--- a/src/test/HST/ApplicationTests.hs
+++ b/src/test/HST/ApplicationTests.hs
@@ -75,7 +75,7 @@ shouldTransformTo input expectedOutput = do
   outputModule         <- runTest $ do
     inputModule'  <- FromHSE.transformModule inputModule
     outputModule' <- processModule inputModule'
-    return (ToHSE.transformModule inputModule outputModule')
+    return (ToHSE.transformModule outputModule')
   outputModule `prettyShouldBe` expectedOutputModule
 
 -- | Pretty prints both values and tests whether the resulting strings are


### PR DESCRIPTION
<!--
  Have you read our Code of Conduct?
  By filing an issue or pull request, you are expected to comply with it, including treating everyone with respect:
  https://github.com/FreeProving/guidelines/blob/main/CODE_OF_CONDUCT.md
-->

### Issue

<!--
  Link to the issue that this pull request addresses.
  If there is not yet a corresponding issue, please open a new issue and then link to that issue in your pull request.
  Give any additional information that is not covered by the linked issue but might be important for the reviewer.
-->
Closes #38.
Closes #17 by completing pattern matching for `S.NegApp`.
Closes #41 in order to complete pattern matching in `HST.Frontend.ToHSE`.

### Description of the Change

<!--
  Give a short summary of the changes you made to handle the issue.
  Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.
-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--
  What process did you follow to verify that your change has the desired effects and has not introduced any regressions?
  Describe the actions you performed (including input you checked, tests you created, commands you ran, etc.), and describe the results you observed.
-->

### Additional Notes

<!-- Is there anything else worth mentioning (e.g. changes by your PR that other contributors have to be aware of, ideas for further enhancements, etc.)? -->

 - Support for `newtype` declarations was added in order to complete pattern matching in `HST.Frontend.FromHSE`. `newtype` declarations can be represented by the existing `DataDecl` nodes.
