### PR TITLE
Upgrade to Cabal 3.2.0.0

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -81,7 +81,7 @@ jobs:
       uses: actions/setup-haskell@v1.1
       with:
         ghc-version: '8.6.5'
-        cabal-version: '2.4'
+        cabal-version: '3.2'
     - name: Update Cabal Package List
       id: cabal-update
       run: cabal new-update
@@ -167,7 +167,7 @@ jobs:
       uses: actions/setup-haskell@v1.1
       with:
         ghc-version: '8.6.5'
-        cabal-version: '2.4'
+        cabal-version: '3.2'
     - name: Update Cabal Package List
       id: cabal-update
       run: cabal new-update
@@ -224,7 +224,7 @@ jobs:
       uses: actions/setup-haskell@v1.1
       with:
         ghc-version: '8.6.5'
-        cabal-version: '2.4'
+        cabal-version: '3.2'
     - name: Update Cabal Package List
       id: cabal-update
       run: cabal new-update

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ To build it, the GHC and Cabal are required.
 The tool has been tested with the following software versions.
 
  - [GHC][software/ghc], version  8.6.5
- - [Cabal][software/cabal], version 2.4.1.0
+ - [Cabal][software/cabal], version 3.2.0.0
 
 ### Executable Installation
 

--- a/haskell-src-transformations.cabal
+++ b/haskell-src-transformations.cabal
@@ -44,15 +44,22 @@ common deps
   --
   -- Polysemy needs a lot of language extensions. The language extensions
   -- which are required in every computation that uses Polysemy effects
-  -- are enabled globally. Language extensions such as `TemplateHaskell`
+  -- are enabled by default. Language extensions such as `TemplateHaskell`
   -- which are needed for the definition of custom effects only are enabled
-  -- for individual files.
+  -- for individual files and are listed as `other-extensions`.
   default-language:    Haskell2010
-  extensions:          DataKinds
+  default-extensions:  DataKinds
                      , FlexibleContexts
                      , GADTs
                      , PolyKinds
                      , TypeOperators
+  other-extensions:    BlockArguments
+                     , FlexibleContexts
+                     , LambdaCase
+                     , ScopedTypeVariables
+                     , StandaloneDeriving
+                     , TemplateHaskell
+                     , TypeFamilies
   ghc-options:         -Wall
 
   -- The Polysemy plugin is currently not supported by Haddock. Thus, the

--- a/tool/test.sh
+++ b/tool/test.sh
@@ -22,9 +22,7 @@ cd "$root_dir"
 # add the `--rerun` option easily.
 failure_report_file=".hspec-failure-report"
 
-# Run tests with cabal.
-# We use `new-run` instead of `new-test`, because Cabal 2.4 does not
-# support `--test-options` to be passed to the test.
+# Run tests with Cabal.
 cabal new-run haskell-src-transformations-unit-tests \
   --ghc-option -Wwarn --                             \
   --failure-report="$failure_report_file"            \


### PR DESCRIPTION
<!--
  Have you read our Code of Conduct?
  By filing an issue or pull request, you are expected to comply with it, including treating everyone with respect:
  https://github.com/FreeProving/guidelines/blob/main/CODE_OF_CONDUCT.md
-->

### Issue

<!--
  Link to the issue that this pull request addresses.
  If there is not yet a corresponding issue, please open a new issue and then link to that issue in your pull request.
  Give any additional information that is not covered by the linked issue but might be important for the reviewer.
-->
Closes #29.

### Description of the Change

<!--
  Give a short summary of the changes you made to handle the issue.
  Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.
-->
 - The CI pipeline was configured to use Cabal `3.2`.
 - The `extensions` field of the `.cabal` file was changed to `default-extensions` since `extensions` is deprecated in Cabal 3.2.
 - Cabal 3.2.0.0 is now listed as *required software* in the README.

### Additional Notes

When using language extensions with a `{-# LANGAUGE #-}` pragma, the language extension should be added to the `other-extensions` field in the `.cabal` file.
