### PR TITLE
Add Expression Parser and Further Tests for Substitutions

### DIFF
--- a/src/lib/HST/Effect/WithFrontend.hs
+++ b/src/lib/HST/Effect/WithFrontend.hs
@@ -88,21 +88,18 @@ runWithFrontendInstances
   => Sem (WithFrontend f ': r) a
   -> Sem r a
 runWithFrontendInstances = interpret \case
-  ParseModule inputFile input          ->
-    HST.Frontend.Parser.parseModule inputFile input
-  TransformModule parsedModule         ->
+  ParseModule inputFile input -> HST.Frontend.Parser.parseModule inputFile input
+  TransformModule parsedModule ->
     HST.Frontend.Transformer.transformModule parsedModule
-  UnTransformModule transformedModule  ->
+  UnTransformModule transformedModule ->
     HST.Frontend.Transformer.unTransformModule transformedModule
-  PrettyPrintModule parsedModule       ->
+  PrettyPrintModule parsedModule ->
     return $ HST.Frontend.PrettyPrinter.prettyPrintModule parsedModule
-  ParseExp input                ->
-    HST.Frontend.Parser.parseExp input
-  TransformExp parsedExp        ->
-    HST.Frontend.Transformer.transformExp parsedExp
+  ParseExp input -> HST.Frontend.Parser.parseExp input
+  TransformExp parsedExp -> HST.Frontend.Transformer.transformExp parsedExp
   UnTransformExp transformedExp ->
     HST.Frontend.Transformer.unTransformExp transformedExp
-  PrettyPrintExp parsedExp      ->
+  PrettyPrintExp parsedExp ->
     return $ HST.Frontend.PrettyPrinter.prettyPrintExp parsedExp
 
 -- | Handles the 'WithFrontend' effect of a polymorphic computation by running

--- a/src/lib/HST/Effect/WithFrontend.hs
+++ b/src/lib/HST/Effect/WithFrontend.hs
@@ -19,10 +19,10 @@ module HST.Effect.WithFrontend
   , transformModule
   , unTransformModule
   , prettyPrintModule
-  , parseExpression
-  , transformExpression
-  , unTransformExpression
-  , prettyPrintExpression
+  , parseExp
+  , transformExp
+  , unTransformExp
+  , prettyPrintExp
     -- * Handlers
   , runWithFrontendInstances
   , runWithFrontend
@@ -37,7 +37,7 @@ import           HST.Effect.Report          ( Report )
 import           HST.Frontend.GHC.Config    ( GHC )
 import           HST.Frontend.HSE.Config    ( HSE )
 import           HST.Frontend.Parser
-  ( Parsable, ParsedExpression, ParsedModule )
+  ( Parsable, ParsedExp, ParsedModule )
 import qualified HST.Frontend.Parser
 import           HST.Frontend.PrettyPrinter ( PrettyPrintable )
 import qualified HST.Frontend.PrettyPrinter
@@ -67,13 +67,13 @@ data WithFrontend f m a where
   PrettyPrintModule :: ParsedModule f -- ^ The module to pretty-print.
     -> WithFrontend f m String
   -- | Action for parsing an expression.
-  ParseExpression :: String -> WithFrontend f m (ParsedExpression f)
+  ParseExp :: String -> WithFrontend f m (ParsedExp f)
   -- | Action for transforming an expression to the intermediate syntax.
-  TransformExpression :: ParsedExpression f -> WithFrontend f m (S.Exp f)
+  TransformExp :: ParsedExp f -> WithFrontend f m (S.Exp f)
   -- | Action for transforming an expression back.
-  UnTransformExpression :: S.Exp f -> WithFrontend f m (ParsedExpression f)
+  UnTransformExp :: S.Exp f -> WithFrontend f m (ParsedExp f)
   -- | Action for pretty printing an expression.
-  PrettyPrintExpression :: ParsedExpression f -> WithFrontend f m String
+  PrettyPrintExp :: ParsedExp f -> WithFrontend f m String
 
 makeSem ''WithFrontend
 
@@ -96,14 +96,14 @@ runWithFrontendInstances = interpret \case
     HST.Frontend.Transformer.unTransformModule transformedModule
   PrettyPrintModule parsedModule       ->
     return $ HST.Frontend.PrettyPrinter.prettyPrintModule parsedModule
-  ParseExpression input                ->
-    HST.Frontend.Parser.parseExpression input
-  TransformExpression parsedExp        ->
-    HST.Frontend.Transformer.transformExpression parsedExp
-  UnTransformExpression transformedExp ->
-    HST.Frontend.Transformer.unTransformExpression transformedExp
-  PrettyPrintExpression parsedExp      ->
-    return $ HST.Frontend.PrettyPrinter.prettyPrintExpression parsedExp
+  ParseExp input                ->
+    HST.Frontend.Parser.parseExp input
+  TransformExp parsedExp        ->
+    HST.Frontend.Transformer.transformExp parsedExp
+  UnTransformExp transformedExp ->
+    HST.Frontend.Transformer.unTransformExp transformedExp
+  PrettyPrintExp parsedExp      ->
+    return $ HST.Frontend.PrettyPrinter.prettyPrintExp parsedExp
 
 -- | Handles the 'WithFrontend' effect of a polymorphic computation by running
 --   the computation with the type class instances for the configuration data

--- a/src/lib/HST/Frontend/Parser.hs
+++ b/src/lib/HST/Frontend/Parser.hs
@@ -54,8 +54,7 @@ class Parsable a where
   --
   --   Syntax errors are reported. The computation can be canceled even if
   --   there is no fatal error.
-  parseExp
-    :: Members '[Report, Cancel] r => String -> Sem r (ParsedExp a)
+  parseExp :: Members '[Report, Cancel] r => String -> Sem r (ParsedExp a)
 
 -- | Parses a Haskell module or expression with the parser of
 --   @haskell-src-exts@.
@@ -73,8 +72,7 @@ instance Parsable HSE where
     parseMode :: HSE.ParseMode
     parseMode = HSE.defaultParseMode { HSE.parseFilename = inputFilename }
 
-  parseExp input = ParsedExpHSE
-    <$> handleParseResultHSE (HSE.parseExp input)
+  parseExp input = ParsedExpHSE <$> handleParseResultHSE (HSE.parseExp input)
 
 -- | Handles a parse result of the HSE front end, i. e. returns the AST node
 --   contained in the parse result or reports an error if parsing failed.
@@ -97,9 +95,8 @@ instance Parsable GHC where
     { getParsedModuleGHC :: GHC.Located (GHC.HsModule GHC.GhcPs)
     }
 
-  data ParsedExp GHC = ParsedExpGHC
-    { getParsedExpGHC :: GHC.Located (GHC.HsExpr GHC.GhcPs)
-    }
+  data ParsedExp GHC
+    = ParsedExpGHC { getParsedExpGHC :: GHC.Located (GHC.HsExpr GHC.GhcPs) }
 
   parseModule inputFilename input = ParsedModuleGHC
     <$> handleParseResultGHC (GHC.parseFile inputFilename defaultDynFlags input)

--- a/src/lib/HST/Frontend/Parser.hs
+++ b/src/lib/HST/Frontend/Parser.hs
@@ -3,13 +3,13 @@
 -- | This module contains functions for parsing Haskell modules and expressions
 --   with the different front ends.
 module HST.Frontend.Parser
-  ( Parsable(parseModule, parseExpression)
+  ( Parsable(parseModule, parseExp)
   , ParsedModule(ParsedModuleHSE, ParsedModuleGHC)
-  , ParsedExpression(ParsedExpressionHSE, ParsedExpressionGHC)
+  , ParsedExp(ParsedExpHSE, ParsedExpGHC)
   , getParsedModuleHSE
   , getParsedModuleGHC
-  , getParsedExpressionHSE
-  , getParsedExpressionGHC
+  , getParsedExpHSE
+  , getParsedExpGHC
   ) where
 
 import qualified Bag                                        as GHC
@@ -38,8 +38,8 @@ class Parsable a where
   -- | Type family for the return type of 'parseModule'.
   data ParsedModule a :: *
 
-  -- | Type family for the return type of 'parseExpression'.
-  data ParsedExpression a :: *
+  -- | Type family for the return type of 'parseExp'.
+  data ParsedExp a :: *
 
   -- | Parses the given Haskell file.
   --
@@ -54,8 +54,8 @@ class Parsable a where
   --
   --   Syntax errors are reported. The computation can be canceled even if
   --   there is no fatal error.
-  parseExpression
-    :: Members '[Report, Cancel] r => String -> Sem r (ParsedExpression a)
+  parseExp
+    :: Members '[Report, Cancel] r => String -> Sem r (ParsedExp a)
 
 -- | Parses a Haskell module or expression with the parser of
 --   @haskell-src-exts@.
@@ -63,8 +63,8 @@ instance Parsable HSE where
   data ParsedModule HSE
     = ParsedModuleHSE { getParsedModuleHSE :: HSE.Module HSE.SrcSpanInfo }
 
-  data ParsedExpression HSE
-    = ParsedExpressionHSE { getParsedExpressionHSE :: HSE.Exp HSE.SrcSpanInfo }
+  data ParsedExp HSE
+    = ParsedExpHSE { getParsedExpHSE :: HSE.Exp HSE.SrcSpanInfo }
 
   parseModule inputFilename input = ParsedModuleHSE
     <$> handleParseResultHSE (HSE.parseModuleWithMode parseMode input)
@@ -73,7 +73,7 @@ instance Parsable HSE where
     parseMode :: HSE.ParseMode
     parseMode = HSE.defaultParseMode { HSE.parseFilename = inputFilename }
 
-  parseExpression input = ParsedExpressionHSE
+  parseExp input = ParsedExpHSE
     <$> handleParseResultHSE (HSE.parseExp input)
 
 -- | Handles a parse result of the HSE front end, i. e. returns the AST node
@@ -97,14 +97,14 @@ instance Parsable GHC where
     { getParsedModuleGHC :: GHC.Located (GHC.HsModule GHC.GhcPs)
     }
 
-  data ParsedExpression GHC = ParsedExpressionGHC
-    { getParsedExpressionGHC :: GHC.Located (GHC.HsExpr GHC.GhcPs)
+  data ParsedExp GHC = ParsedExpGHC
+    { getParsedExpGHC :: GHC.Located (GHC.HsExpr GHC.GhcPs)
     }
 
   parseModule inputFilename input = ParsedModuleGHC
     <$> handleParseResultGHC (GHC.parseFile inputFilename defaultDynFlags input)
 
-  parseExpression input = ParsedExpressionGHC
+  parseExp input = ParsedExpGHC
     <$> handleParseResultGHC (GHC.parseExpression input defaultDynFlags)
 
 -- | Handles a parse result of the GHC front end, i. e. returns the AST node

--- a/src/lib/HST/Frontend/PrettyPrinter.hs
+++ b/src/lib/HST/Frontend/PrettyPrinter.hs
@@ -1,7 +1,7 @@
 -- | This module contains functions for pretty-printing modules and expressions
 --   that have been converted back from the intermediate representation.
 module HST.Frontend.PrettyPrinter
-  ( PrettyPrintable(prettyPrintModule, prettyPrintExpression)
+  ( PrettyPrintable(prettyPrintModule, prettyPrintExp)
   ) where
 
 import qualified Language.Haskell.Exts   as HSE
@@ -10,18 +10,18 @@ import qualified Outputable              as GHC
 import           HST.Frontend.GHC.Config ( GHC, defaultDynFlags )
 import           HST.Frontend.HSE.Config ( HSE )
 import           HST.Frontend.Parser
-  ( ParsedExpression, ParsedModule, getParsedExpressionGHC
-  , getParsedExpressionHSE, getParsedModuleGHC, getParsedModuleHSE )
+  ( ParsedExp, ParsedModule, getParsedExpGHC
+  , getParsedExpHSE, getParsedModuleGHC, getParsedModuleHSE )
 
 -- | Type class for "HST.Frontend.Syntax" configurations whose 'ParsedModule's
---   and 'ParsedExpression's can be pretty-printed.
+--   and 'ParsedExp's can be pretty-printed.
 class PrettyPrintable a where
   -- | Pretty prints the given module.
   prettyPrintModule :: ParsedModule a -- ^ The module to pretty-print.
                     -> String
 
   -- | Pretty prints the given expression.
-  prettyPrintExpression :: ParsedExpression a -> String
+  prettyPrintExp :: ParsedExp a -> String
 
 -- | Pretty prints the given Haskell module or expression with the pretty
 --   printer of @haskell-src-exts@.
@@ -29,8 +29,8 @@ instance PrettyPrintable HSE where
   prettyPrintModule
     = HSE.prettyPrintStyleMode styleHSE HSE.defaultMode . getParsedModuleHSE
 
-  prettyPrintExpression = HSE.prettyPrintStyleMode styleHSE HSE.defaultMode
-    . getParsedExpressionHSE
+  prettyPrintExp = HSE.prettyPrintStyleMode styleHSE HSE.defaultMode
+    . getParsedExpHSE
 
 -- | The pretty-printing style used with the @haskell-src-exts@ front end.
 styleHSE :: HSE.Style
@@ -44,4 +44,4 @@ styleHSE = HSE.Style { HSE.mode           = HSE.PageMode
 instance PrettyPrintable GHC where
   prettyPrintModule     = GHC.showPpr defaultDynFlags . getParsedModuleGHC
 
-  prettyPrintExpression = GHC.showPpr defaultDynFlags . getParsedExpressionGHC
+  prettyPrintExp = GHC.showPpr defaultDynFlags . getParsedExpGHC

--- a/src/lib/HST/Frontend/PrettyPrinter.hs
+++ b/src/lib/HST/Frontend/PrettyPrinter.hs
@@ -1,6 +1,8 @@
--- | This module contains functions for pretty-printing modules that have
---   been converted back from the intermediate representation.
-module HST.Frontend.PrettyPrinter ( PrettyPrintable(prettyPrintModule) ) where
+-- | This module contains functions for pretty-printing modules and expressions
+--   that have been converted back from the intermediate representation.
+module HST.Frontend.PrettyPrinter
+  ( PrettyPrintable(prettyPrintModule, prettyPrintExpression)
+  ) where
 
 import qualified Language.Haskell.Exts   as HSE
 import qualified Outputable              as GHC
@@ -8,26 +10,38 @@ import qualified Outputable              as GHC
 import           HST.Frontend.GHC.Config ( GHC, defaultDynFlags )
 import           HST.Frontend.HSE.Config ( HSE )
 import           HST.Frontend.Parser
-  ( ParsedModule, getParsedModuleGHC, getParsedModuleHSE )
+  ( ParsedExpression, ParsedModule, getParsedExpressionGHC
+  , getParsedExpressionHSE, getParsedModuleGHC, getParsedModuleHSE )
 
 -- | Type class for "HST.Frontend.Syntax" configurations whose 'ParsedModule's
---   can be pretty-printed.
+--   and 'ParsedExpression's can be pretty-printed.
 class PrettyPrintable a where
   -- | Pretty prints the given module.
   prettyPrintModule :: ParsedModule a -- ^ The module to pretty-print.
                     -> String
 
--- | Pretty prints the given Haskell module with the pretty printer of
---   @haskell-src-exts@.
-instance PrettyPrintable HSE where
-  prettyPrintModule = HSE.prettyPrintStyleMode
-    (HSE.Style { HSE.mode           = HSE.PageMode
-               , HSE.lineLength     = 80
-               , HSE.ribbonsPerLine = 1.0
-               }) HSE.defaultMode
-    . getParsedModuleHSE
+  -- | Pretty prints the given expression.
+  prettyPrintExpression :: ParsedExpression a -> String
 
--- | Pretty prints the given Haskell module with the pretty printer of
---   @ghc-lib-parser@.
+-- | Pretty prints the given Haskell module or expression with the pretty
+--   printer of @haskell-src-exts@.
+instance PrettyPrintable HSE where
+  prettyPrintModule
+    = HSE.prettyPrintStyleMode styleHSE HSE.defaultMode . getParsedModuleHSE
+
+  prettyPrintExpression = HSE.prettyPrintStyleMode styleHSE HSE.defaultMode
+    . getParsedExpressionHSE
+
+-- | The pretty-printing style used with the @haskell-src-exts@ front end.
+styleHSE :: HSE.Style
+styleHSE = HSE.Style { HSE.mode           = HSE.PageMode
+                     , HSE.lineLength     = 80
+                     , HSE.ribbonsPerLine = 1.0
+                     }
+
+-- | Pretty prints the given Haskell module or expression with the pretty
+--   printer of @ghc-lib-parser@.
 instance PrettyPrintable GHC where
-  prettyPrintModule = GHC.showPpr defaultDynFlags . getParsedModuleGHC
+  prettyPrintModule     = GHC.showPpr defaultDynFlags . getParsedModuleGHC
+
+  prettyPrintExpression = GHC.showPpr defaultDynFlags . getParsedExpressionGHC

--- a/src/lib/HST/Frontend/PrettyPrinter.hs
+++ b/src/lib/HST/Frontend/PrettyPrinter.hs
@@ -10,8 +10,8 @@ import qualified Outputable              as GHC
 import           HST.Frontend.GHC.Config ( GHC, defaultDynFlags )
 import           HST.Frontend.HSE.Config ( HSE )
 import           HST.Frontend.Parser
-  ( ParsedExp, ParsedModule, getParsedExpGHC
-  , getParsedExpHSE, getParsedModuleGHC, getParsedModuleHSE )
+  ( ParsedExp, ParsedModule, getParsedExpGHC, getParsedExpHSE
+  , getParsedModuleGHC, getParsedModuleHSE )
 
 -- | Type class for "HST.Frontend.Syntax" configurations whose 'ParsedModule's
 --   and 'ParsedExp's can be pretty-printed.
@@ -29,8 +29,8 @@ instance PrettyPrintable HSE where
   prettyPrintModule
     = HSE.prettyPrintStyleMode styleHSE HSE.defaultMode . getParsedModuleHSE
 
-  prettyPrintExp = HSE.prettyPrintStyleMode styleHSE HSE.defaultMode
-    . getParsedExpHSE
+  prettyPrintExp
+    = HSE.prettyPrintStyleMode styleHSE HSE.defaultMode . getParsedExpHSE
 
 -- | The pretty-printing style used with the @haskell-src-exts@ front end.
 styleHSE :: HSE.Style
@@ -42,6 +42,6 @@ styleHSE = HSE.Style { HSE.mode           = HSE.PageMode
 -- | Pretty prints the given Haskell module or expression with the pretty
 --   printer of @ghc-lib-parser@.
 instance PrettyPrintable GHC where
-  prettyPrintModule     = GHC.showPpr defaultDynFlags . getParsedModuleGHC
+  prettyPrintModule = GHC.showPpr defaultDynFlags . getParsedModuleGHC
 
-  prettyPrintExp = GHC.showPpr defaultDynFlags . getParsedExpGHC
+  prettyPrintExp    = GHC.showPpr defaultDynFlags . getParsedExpGHC

--- a/src/lib/HST/Frontend/Transformer.hs
+++ b/src/lib/HST/Frontend/Transformer.hs
@@ -13,13 +13,13 @@ import           HST.Frontend.HSE.Config ( HSE )
 import qualified HST.Frontend.HSE.From   as FromHSE
 import qualified HST.Frontend.HSE.To     as ToHSE
 import           HST.Frontend.Parser
-  ( ParsedExpression(ParsedExpressionHSE, ParsedExpressionGHC)
-  , ParsedModule(ParsedModuleGHC, ParsedModuleHSE), getParsedExpressionGHC
-  , getParsedExpressionHSE, getParsedModuleGHC, getParsedModuleHSE )
+  ( ParsedExp(ParsedExpHSE, ParsedExpGHC)
+  , ParsedModule(ParsedModuleGHC, ParsedModuleHSE), getParsedExpGHC
+  , getParsedExpHSE, getParsedModuleGHC, getParsedModuleHSE )
 import qualified HST.Frontend.Syntax     as S
 
 -- | Type class for "HST.Frontend.Syntax" configurations whose 'ParsedModule's
---   and 'ParsedExpression's can be transformed to and from the intermediate
+--   and 'ParsedExp's can be transformed to and from the intermediate
 --   syntax.
 class Transformable a where
   -- | Transforms a parsed module to the intermediate syntax.
@@ -34,28 +34,28 @@ class Transformable a where
                     -> Sem r (ParsedModule a)
 
   -- | Transforms a parsed expression to the intermediate syntax.
-  transformExpression
-    :: Member Report r => ParsedExpression a -> Sem r (S.Exp a)
+  transformExp
+    :: Member Report r => ParsedExp a -> Sem r (S.Exp a)
 
   -- | Transforms an expression from the intermediate syntax back to a pretty
   --   printable expression.
-  unTransformExpression
-    :: Member Report r => S.Exp a -> Sem r (ParsedExpression a)
+  unTransformExp
+    :: Member Report r => S.Exp a -> Sem r (ParsedExp a)
 
 instance Transformable HSE where
   transformModule       = FromHSE.transformModule . getParsedModuleHSE
 
   unTransformModule     = return . ParsedModuleHSE . ToHSE.transformModule
 
-  transformExpression   = FromHSE.transformExp . getParsedExpressionHSE
+  transformExp   = FromHSE.transformExp . getParsedExpHSE
 
-  unTransformExpression = return . ParsedExpressionHSE . ToHSE.transformExp
+  unTransformExp = return . ParsedExpHSE . ToHSE.transformExp
 
 instance Transformable GHC where
   transformModule       = FromGHC.transformModule . getParsedModuleGHC
 
   unTransformModule     = fmap ParsedModuleGHC . ToGHC.transformModule
 
-  transformExpression   = FromGHC.transformExpr . getParsedExpressionGHC
+  transformExp   = FromGHC.transformExpr . getParsedExpGHC
 
-  unTransformExpression = fmap ParsedExpressionGHC . ToGHC.transformExp
+  unTransformExp = fmap ParsedExpGHC . ToGHC.transformExp

--- a/src/lib/HST/Frontend/Transformer.hs
+++ b/src/lib/HST/Frontend/Transformer.hs
@@ -1,5 +1,6 @@
--- | This module contains functions for transforming parsed Haskell modules
---   with the different front ends to the intermediate syntax and back.
+-- | This module contains functions for transforming parsed Haskell modules and
+--   expressions with the different front ends to the intermediate syntax and
+--   back.
 module HST.Frontend.Transformer ( Transformable(..) ) where
 
 import           Polysemy                ( Member, Sem )
@@ -12,12 +13,14 @@ import           HST.Frontend.HSE.Config ( HSE )
 import qualified HST.Frontend.HSE.From   as FromHSE
 import qualified HST.Frontend.HSE.To     as ToHSE
 import           HST.Frontend.Parser
-  ( ParsedModule(ParsedModuleGHC, ParsedModuleHSE), getParsedModuleGHC
-  , getParsedModuleHSE )
+  ( ParsedExpression(ParsedExpressionHSE, ParsedExpressionGHC)
+  , ParsedModule(ParsedModuleGHC, ParsedModuleHSE), getParsedExpressionGHC
+  , getParsedExpressionHSE, getParsedModuleGHC, getParsedModuleHSE )
 import qualified HST.Frontend.Syntax     as S
 
--- | Type class for "HST.Frontend.Syntax" configurations whose 'ParsedModule'
---   can be transformed to and from the intermediate syntax.
+-- | Type class for "HST.Frontend.Syntax" configurations whose 'ParsedModule's
+--   and 'ParsedExpression's can be transformed to and from the intermediate
+--   syntax.
 class Transformable a where
   -- | Transforms a parsed module to the intermediate syntax.
   transformModule :: Member Report r
@@ -30,12 +33,29 @@ class Transformable a where
                     => S.Module a     -- ^ The module to transform.
                     -> Sem r (ParsedModule a)
 
-instance Transformable HSE where
-  transformModule   = FromHSE.transformModule . getParsedModuleHSE
+  -- | Transforms a parsed expression to the intermediate syntax.
+  transformExpression
+    :: Member Report r => ParsedExpression a -> Sem r (S.Exp a)
 
-  unTransformModule = return . ParsedModuleHSE . ToHSE.transformModule
+  -- | Transforms an expression from the intermediate syntax back to a pretty
+  --   printable expression.
+  unTransformExpression
+    :: Member Report r => S.Exp a -> Sem r (ParsedExpression a)
+
+instance Transformable HSE where
+  transformModule       = FromHSE.transformModule . getParsedModuleHSE
+
+  unTransformModule     = return . ParsedModuleHSE . ToHSE.transformModule
+
+  transformExpression   = FromHSE.transformExp . getParsedExpressionHSE
+
+  unTransformExpression = return . ParsedExpressionHSE . ToHSE.transformExp
 
 instance Transformable GHC where
-  transformModule   = FromGHC.transformModule . getParsedModuleGHC
+  transformModule       = FromGHC.transformModule . getParsedModuleGHC
 
-  unTransformModule = fmap ParsedModuleGHC . ToGHC.transformModule
+  unTransformModule     = fmap ParsedModuleGHC . ToGHC.transformModule
+
+  transformExpression   = FromGHC.transformExpr . getParsedExpressionGHC
+
+  unTransformExpression = fmap ParsedExpressionGHC . ToGHC.transformExp

--- a/src/lib/HST/Frontend/Transformer.hs
+++ b/src/lib/HST/Frontend/Transformer.hs
@@ -34,28 +34,26 @@ class Transformable a where
                     -> Sem r (ParsedModule a)
 
   -- | Transforms a parsed expression to the intermediate syntax.
-  transformExp
-    :: Member Report r => ParsedExp a -> Sem r (S.Exp a)
+  transformExp :: Member Report r => ParsedExp a -> Sem r (S.Exp a)
 
   -- | Transforms an expression from the intermediate syntax back to a pretty
   --   printable expression.
-  unTransformExp
-    :: Member Report r => S.Exp a -> Sem r (ParsedExp a)
+  unTransformExp :: Member Report r => S.Exp a -> Sem r (ParsedExp a)
 
 instance Transformable HSE where
-  transformModule       = FromHSE.transformModule . getParsedModuleHSE
+  transformModule   = FromHSE.transformModule . getParsedModuleHSE
 
-  unTransformModule     = return . ParsedModuleHSE . ToHSE.transformModule
+  unTransformModule = return . ParsedModuleHSE . ToHSE.transformModule
 
-  transformExp   = FromHSE.transformExp . getParsedExpHSE
+  transformExp      = FromHSE.transformExp . getParsedExpHSE
 
-  unTransformExp = return . ParsedExpHSE . ToHSE.transformExp
+  unTransformExp    = return . ParsedExpHSE . ToHSE.transformExp
 
 instance Transformable GHC where
-  transformModule       = FromGHC.transformModule . getParsedModuleGHC
+  transformModule   = FromGHC.transformModule . getParsedModuleGHC
 
-  unTransformModule     = fmap ParsedModuleGHC . ToGHC.transformModule
+  unTransformModule = fmap ParsedModuleGHC . ToGHC.transformModule
 
-  transformExp   = FromGHC.transformExpr . getParsedExpGHC
+  transformExp      = FromGHC.transformExpr . getParsedExpGHC
 
-  unTransformExp = fmap ParsedExpGHC . ToGHC.transformExp
+  unTransformExp    = fmap ParsedExpGHC . ToGHC.transformExp

--- a/src/test/HST/ApplicationTests.hs
+++ b/src/test/HST/ApplicationTests.hs
@@ -16,7 +16,7 @@ testApplication :: Spec
 testApplication = describe "HST.Application" $ do
   testProcessModule
 
--- | Test cases for 'processModule'.
+-- | Test cases for 'HST.Application.processModule'.
 testProcessModule :: Spec
 testProcessModule = context "processModule" $ do
   it "should leave functions without pattern matching unchanged"

--- a/src/test/HST/ApplicationTests.hs
+++ b/src/test/HST/ApplicationTests.hs
@@ -3,39 +3,10 @@
 -- | This module contains basic tests for "HST.Application".
 module HST.ApplicationTests ( testApplication ) where
 
-import           Polysemy                  ( Members, Sem )
 import           Test.Hspec                ( Spec, context, describe, it )
 
-import           HST.Application           ( processModule )
-import           HST.Effect.Cancel         ( Cancel )
-import           HST.Effect.Env            ( runEnv )
-import           HST.Effect.Fresh          ( runFresh )
-import           HST.Effect.GetOpt         ( GetOpt )
-import           HST.Effect.Report         ( Report )
-import           HST.Effect.SetExpectation ( SetExpectation )
-import           HST.Effect.WithFrontend   ( WithFrontend )
-import qualified HST.Frontend.Syntax       as S
-import           HST.Test.Expectation      ( prettyModuleShouldBe )
-import           HST.Test.Parser           ( parseTestModule )
+import           HST.Test.Expectation      ( shouldTransformTo )
 import           HST.Test.Runner           ( runTest )
-
--------------------------------------------------------------------------------
--- Expectation Setters                                                       --
--------------------------------------------------------------------------------
--- | Parses the given modules, processes the input module with 'processModule'
---   and sets the expectation that the given output module is produced.
-shouldTransformTo
-  :: ( S.EqAST f
-     , Members '[GetOpt, Cancel, Report, SetExpectation, WithFrontend f] r
-     )
-  => [String]
-  -> [String]
-  -> Sem r ()
-shouldTransformTo input expectedOutput = do
-  inputModule <- parseTestModule input
-  outputModule <- runEnv . runFresh $ processModule inputModule
-  expectedOutputModule <- parseTestModule expectedOutput
-  outputModule `prettyModuleShouldBe` expectedOutputModule
 
 -------------------------------------------------------------------------------
 -- Tests                                                                     --

--- a/src/test/HST/ApplicationTests.hs
+++ b/src/test/HST/ApplicationTests.hs
@@ -3,10 +3,10 @@
 -- | This module contains basic tests for "HST.Application".
 module HST.ApplicationTests ( testApplication ) where
 
-import           Test.Hspec                ( Spec, context, describe, it )
+import           Test.Hspec           ( Spec, context, describe, it )
 
-import           HST.Test.Expectation      ( shouldTransformTo )
-import           HST.Test.Runner           ( runTest )
+import           HST.Test.Expectation ( shouldTransformTo )
+import           HST.Test.Runner      ( runTest )
 
 -------------------------------------------------------------------------------
 -- Tests                                                                     --

--- a/src/test/HST/ApplicationTests.hs
+++ b/src/test/HST/ApplicationTests.hs
@@ -3,7 +3,8 @@
 -- | This module contains basic tests for "HST.Application".
 module HST.ApplicationTests ( testApplication ) where
 
-import           Test.Hspec           ( Spec, context, describe, it )
+import           Polysemy                  ( Members, Sem )
+import           Test.Hspec                ( Spec, context, describe, it )
 
 import           HST.Application           ( processModule )
 import           HST.Effect.Cancel         ( Cancel )
@@ -105,3 +106,39 @@ testProcessModule = context "processModule" $ do
     , "      a4 = undefined"
     , "  in  a3"
     ]
+  context "substitution in modules" $ do
+    it "avoids capture of variables shadowed in let expressions"
+      $ runTest
+      $ let m        = ["module A where", "f (x, y) = let x = y in x"]
+            expected = [ "module A where"
+                       , "f a0 = case a0 of"
+                       , "  (a1, a2) -> let x = a2 in x"
+                       ]
+        in m `shouldTransformTo` expected
+    {- TODO The following test should be used instead of the replacement that
+        is not commented out, after the corresponding issue has been fixed.
+    it "avoids capture of variables shadowed in case expressions" $ runTest $
+      let m        = [ "module A where"
+                     , "f (x, y) = case x of"
+                     , "             y -> (x, y)"]
+          expected = [ "module A where"
+                     , "f a0 = case a0 of"
+                     , "  (a1, a2) -> case a1 of"
+                     , "    y -> (a1, y)"]
+      in m `shouldTransformTo` expected -}
+    it "avoids capture of variables shadowed in case expressions"
+      $ runTest
+      $ let m        = [ "module A where"
+                       , "f (x, y) ="
+                       , "  let r = case x of"
+                       , "            y -> (x, y)"
+                       , "  in  r"
+                       ]
+            expected = [ "module A where"
+                       , "f a1 = case a1 of"
+                       , "  (a2, a3) ->"
+                       , "    let r = case a2 of"
+                       , "              a0 -> (a2, a0)"
+                       , "    in  r"
+                       ]
+        in m `shouldTransformTo` expected

--- a/src/test/HST/Test/Expectation.hs
+++ b/src/test/HST/Test/Expectation.hs
@@ -6,8 +6,8 @@ import           Test.Hspec                ( shouldBe )
 
 import           HST.Effect.SetExpectation ( SetExpectation, setExpectation )
 import           HST.Effect.WithFrontend
-  ( WithFrontend, prettyPrintExpression, prettyPrintModule
-  , unTransformExpression, unTransformModule )
+  ( WithFrontend, prettyPrintExp, prettyPrintModule
+  , unTransformExp, unTransformModule )
 import qualified HST.Frontend.Syntax       as S
 
 -- | Pretty prints both given modules and tests whether the resulting strings
@@ -23,11 +23,11 @@ prettyModuleShouldBe m1 m2 = do
 
 -- | Pretty prints both given expressions and tests whether the resulting
 --   strings are equal modulo whitespace.
-prettyExpressionShouldBe :: Members '[SetExpectation, WithFrontend f] r
+prettyExpShouldBe :: Members '[SetExpectation, WithFrontend f] r
                          => S.Exp f
                          -> S.Exp f
                          -> Sem r ()
-prettyExpressionShouldBe e1 e2 = do
-  p1 <- unTransformExpression e1 >>= prettyPrintExpression
-  p2 <- unTransformExpression e2 >>= prettyPrintExpression
+prettyExpShouldBe e1 e2 = do
+  p1 <- unTransformExp e1 >>= prettyPrintExp
+  p2 <- unTransformExp e2 >>= prettyPrintExp
   setExpectation (p1 `shouldBe` p2)

--- a/src/test/HST/Test/Expectation.hs
+++ b/src/test/HST/Test/Expectation.hs
@@ -4,11 +4,33 @@ module HST.Test.Expectation where
 import           Polysemy                  ( Members, Sem )
 import           Test.Hspec                ( shouldBe )
 
+import           HST.Application           ( processModule )
+import           HST.Effect.Cancel         ( Cancel )
+import           HST.Effect.Env            ( runEnv )
+import           HST.Effect.Fresh          ( runFresh )
+import           HST.Effect.GetOpt         ( GetOpt )
+import           HST.Effect.Report         ( Report )
 import           HST.Effect.SetExpectation ( SetExpectation, setExpectation )
 import           HST.Effect.WithFrontend
   ( WithFrontend, prettyPrintExpression, prettyPrintModule
   , unTransformExpression, unTransformModule )
-import           HST.Frontend.Syntax       as S
+import qualified HST.Frontend.Syntax       as S
+import           HST.Test.Parser           ( parseTestModule )
+
+-- | Parses the given modules, processes the input module with 'processModule'
+--   and sets the expectation that the given output module is produced.
+shouldTransformTo
+  :: ( S.EqAST f
+     , Members '[GetOpt, Cancel, Report, SetExpectation, WithFrontend f] r
+     )
+  => [String]
+  -> [String]
+  -> Sem r ()
+shouldTransformTo input expectedOutput = do
+  inputModule <- parseTestModule input
+  outputModule <- runEnv . runFresh $ processModule inputModule
+  expectedOutputModule <- parseTestModule expectedOutput
+  outputModule `prettyModuleShouldBe` expectedOutputModule
 
 -- | Pretty prints both given modules and tests whether the resulting strings
 --   are equal modulo whitespace.

--- a/src/test/HST/Test/Expectation.hs
+++ b/src/test/HST/Test/Expectation.hs
@@ -6,7 +6,8 @@ import           Test.Hspec                ( shouldBe )
 
 import           HST.Effect.SetExpectation ( SetExpectation, setExpectation )
 import           HST.Effect.WithFrontend
-  ( WithFrontend, prettyPrintModule, unTransformModule )
+  ( WithFrontend, prettyPrintExpression, prettyPrintModule
+  , unTransformExpression, unTransformModule )
 import           HST.Frontend.Syntax       as S
 
 -- | Pretty prints both given modules and tests whether the resulting strings
@@ -18,4 +19,15 @@ prettyModuleShouldBe :: Members '[SetExpectation, WithFrontend f] r
 prettyModuleShouldBe m1 m2 = do
   p1 <- unTransformModule m1 >>= prettyPrintModule
   p2 <- unTransformModule m2 >>= prettyPrintModule
+  setExpectation (p1 `shouldBe` p2)
+
+-- | Pretty prints both given expressions and tests whether the resulting
+--   strings are equal modulo whitespace.
+prettyExpressionShouldBe :: Members '[SetExpectation, WithFrontend f] r
+                         => S.Exp f
+                         -> S.Exp f
+                         -> Sem r ()
+prettyExpressionShouldBe e1 e2 = do
+  p1 <- unTransformExpression e1 >>= prettyPrintExpression
+  p2 <- unTransformExpression e2 >>= prettyPrintExpression
   setExpectation (p1 `shouldBe` p2)

--- a/src/test/HST/Test/Expectation.hs
+++ b/src/test/HST/Test/Expectation.hs
@@ -6,8 +6,8 @@ import           Test.Hspec                ( shouldBe )
 
 import           HST.Effect.SetExpectation ( SetExpectation, setExpectation )
 import           HST.Effect.WithFrontend
-  ( WithFrontend, prettyPrintExp, prettyPrintModule
-  , unTransformExp, unTransformModule )
+  ( WithFrontend, prettyPrintExp, prettyPrintModule, unTransformExp
+  , unTransformModule )
 import qualified HST.Frontend.Syntax       as S
 
 -- | Pretty prints both given modules and tests whether the resulting strings
@@ -24,9 +24,9 @@ prettyModuleShouldBe m1 m2 = do
 -- | Pretty prints both given expressions and tests whether the resulting
 --   strings are equal modulo whitespace.
 prettyExpShouldBe :: Members '[SetExpectation, WithFrontend f] r
-                         => S.Exp f
-                         -> S.Exp f
-                         -> Sem r ()
+                  => S.Exp f
+                  -> S.Exp f
+                  -> Sem r ()
 prettyExpShouldBe e1 e2 = do
   p1 <- unTransformExp e1 >>= prettyPrintExp
   p2 <- unTransformExp e2 >>= prettyPrintExp

--- a/src/test/HST/Test/Expectation.hs
+++ b/src/test/HST/Test/Expectation.hs
@@ -4,33 +4,11 @@ module HST.Test.Expectation where
 import           Polysemy                  ( Members, Sem )
 import           Test.Hspec                ( shouldBe )
 
-import           HST.Application           ( processModule )
-import           HST.Effect.Cancel         ( Cancel )
-import           HST.Effect.Env            ( runEnv )
-import           HST.Effect.Fresh          ( runFresh )
-import           HST.Effect.GetOpt         ( GetOpt )
-import           HST.Effect.Report         ( Report )
 import           HST.Effect.SetExpectation ( SetExpectation, setExpectation )
 import           HST.Effect.WithFrontend
   ( WithFrontend, prettyPrintExpression, prettyPrintModule
   , unTransformExpression, unTransformModule )
 import qualified HST.Frontend.Syntax       as S
-import           HST.Test.Parser           ( parseTestModule )
-
--- | Parses the given modules, processes the input module with 'processModule'
---   and sets the expectation that the given output module is produced.
-shouldTransformTo
-  :: ( S.EqAST f
-     , Members '[GetOpt, Cancel, Report, SetExpectation, WithFrontend f] r
-     )
-  => [String]
-  -> [String]
-  -> Sem r ()
-shouldTransformTo input expectedOutput = do
-  inputModule <- parseTestModule input
-  outputModule <- runEnv . runFresh $ processModule inputModule
-  expectedOutputModule <- parseTestModule expectedOutput
-  outputModule `prettyModuleShouldBe` expectedOutputModule
 
 -- | Pretty prints both given modules and tests whether the resulting strings
 --   are equal modulo whitespace.

--- a/src/test/HST/Test/Parser.hs
+++ b/src/test/HST/Test/Parser.hs
@@ -19,5 +19,5 @@ parseTestModule = (parseModule "<test-input>" >=> transformModule) . unlines
 
 -- | Parses an expression for testing purposes.
 parseTestExp
-  :: Members '[Cancel, Report, WithFrontend f] r => [String] -> Sem r (S.Exp f)
-parseTestExp = (parseExp >=> transformExp) . unlines
+  :: Members '[Cancel, Report, WithFrontend f] r => String -> Sem r (S.Exp f)
+parseTestExp = parseExp >=> transformExp

--- a/src/test/HST/Test/Parser.hs
+++ b/src/test/HST/Test/Parser.hs
@@ -7,7 +7,7 @@ import           Polysemy                ( Members, Sem )
 import           HST.Effect.Cancel       ( Cancel )
 import           HST.Effect.Report       ( Report )
 import           HST.Effect.WithFrontend
-  ( WithFrontend, parseExpression, parseModule, transformExpression
+  ( WithFrontend, parseExp, parseModule, transformExp
   , transformModule )
 import qualified HST.Frontend.Syntax     as S
 
@@ -18,6 +18,6 @@ parseTestModule :: Members '[Cancel, Report, WithFrontend f] r
 parseTestModule = (parseModule "<test-input>" >=> transformModule) . unlines
 
 -- | Parses an expression for testing purposes.
-parseTestExpression
+parseTestExp
   :: Members '[Cancel, Report, WithFrontend f] r => [String] -> Sem r (S.Exp f)
-parseTestExpression = (parseExpression >=> transformExpression) . unlines
+parseTestExp = (parseExp >=> transformExp) . unlines

--- a/src/test/HST/Test/Parser.hs
+++ b/src/test/HST/Test/Parser.hs
@@ -7,8 +7,7 @@ import           Polysemy                ( Members, Sem )
 import           HST.Effect.Cancel       ( Cancel )
 import           HST.Effect.Report       ( Report )
 import           HST.Effect.WithFrontend
-  ( WithFrontend, parseExp, parseModule, transformExp
-  , transformModule )
+  ( WithFrontend, parseExp, parseModule, transformExp, transformModule )
 import qualified HST.Frontend.Syntax     as S
 
 -- | Parses a module for testing purposes.

--- a/src/test/HST/Test/Parser.hs
+++ b/src/test/HST/Test/Parser.hs
@@ -1,17 +1,40 @@
 -- | This module contains functions for parsing AST nodes for testing purposes.
 module HST.Test.Parser where
 
-import           Control.Monad           ( (>=>) )
-import           Polysemy                ( Members, Sem )
+import           Control.Monad                              ( (>=>) )
+import qualified Language.Haskell.Exts                      as HSE
+import qualified Language.Haskell.GhclibParserEx.GHC.Parser as GHC
+import           Polysemy
+  ( Member, Members, Sem )
 
-import           HST.Effect.Cancel       ( Cancel )
-import           HST.Effect.Report       ( Report )
+import           HST.Effect.Cancel                          ( Cancel )
+import           HST.Effect.Report                          ( Report )
 import           HST.Effect.WithFrontend
   ( WithFrontend, parseModule, transformModule )
-import           HST.Frontend.Syntax     as S
+import           HST.Frontend.GHC.Config
+  ( GHC, defaultDynFlags )
+import qualified HST.Frontend.GHC.From                      as FromGHC
+import           HST.Frontend.HSE.Config                    ( HSE )
+import qualified HST.Frontend.HSE.From                      as FromHSE
+import           HST.Frontend.Parser
+  ( handleParseResultGHC, handleParseResultHSE )
+import qualified HST.Frontend.Syntax                        as S
 
 -- | Parses a module for testing purposes.
 parseTestModule :: Members '[Cancel, Report, WithFrontend f] r
                 => [String]
                 -> Sem r (S.Module f)
 parseTestModule = (parseModule "<test-input>" >=> transformModule) . unlines
+
+-- | Parses an expression with the GHC front end for testing purposes.
+parseTestExpressionGHC
+  :: Members '[Cancel, Report] r => [String] -> Sem r (S.Exp GHC)
+parseTestExpressionGHC expString = handleParseResultGHC
+  (GHC.parseExpression (unlines expString) defaultDynFlags)
+  >>= FromGHC.transformExpr
+
+-- | Parses an expression with the HSE front end for testing purposes.
+parseTestExpressionHSE :: Member Report r => [String] -> Sem r (S.Exp HSE)
+parseTestExpressionHSE expString = handleParseResultHSE
+  (HSE.parseExp (unlines expString))
+  >>= FromHSE.transformExp

--- a/src/test/HST/Test/Parser.hs
+++ b/src/test/HST/Test/Parser.hs
@@ -1,24 +1,15 @@
 -- | This module contains functions for parsing AST nodes for testing purposes.
 module HST.Test.Parser where
 
-import           Control.Monad                              ( (>=>) )
-import qualified Language.Haskell.Exts                      as HSE
-import qualified Language.Haskell.GhclibParserEx.GHC.Parser as GHC
-import           Polysemy
-  ( Member, Members, Sem )
+import           Control.Monad           ( (>=>) )
+import           Polysemy                ( Members, Sem )
 
-import           HST.Effect.Cancel                          ( Cancel )
-import           HST.Effect.Report                          ( Report )
+import           HST.Effect.Cancel       ( Cancel )
+import           HST.Effect.Report       ( Report )
 import           HST.Effect.WithFrontend
-  ( WithFrontend, parseModule, transformModule )
-import           HST.Frontend.GHC.Config
-  ( GHC, defaultDynFlags )
-import qualified HST.Frontend.GHC.From                      as FromGHC
-import           HST.Frontend.HSE.Config                    ( HSE )
-import qualified HST.Frontend.HSE.From                      as FromHSE
-import           HST.Frontend.Parser
-  ( handleParseResultGHC, handleParseResultHSE )
-import qualified HST.Frontend.Syntax                        as S
+  ( WithFrontend, parseExpression, parseModule, transformExpression
+  , transformModule )
+import qualified HST.Frontend.Syntax     as S
 
 -- | Parses a module for testing purposes.
 parseTestModule :: Members '[Cancel, Report, WithFrontend f] r
@@ -26,15 +17,7 @@ parseTestModule :: Members '[Cancel, Report, WithFrontend f] r
                 -> Sem r (S.Module f)
 parseTestModule = (parseModule "<test-input>" >=> transformModule) . unlines
 
--- | Parses an expression with the GHC front end for testing purposes.
-parseTestExpressionGHC
-  :: Members '[Cancel, Report] r => [String] -> Sem r (S.Exp GHC)
-parseTestExpressionGHC expString = handleParseResultGHC
-  (GHC.parseExpression (unlines expString) defaultDynFlags)
-  >>= FromGHC.transformExpr
-
--- | Parses an expression with the HSE front end for testing purposes.
-parseTestExpressionHSE :: Member Report r => [String] -> Sem r (S.Exp HSE)
-parseTestExpressionHSE expString = handleParseResultHSE
-  (HSE.parseExp (unlines expString))
-  >>= FromHSE.transformExp
+-- | Parses an expression for testing purposes.
+parseTestExpression
+  :: Members '[Cancel, Report, WithFrontend f] r => [String] -> Sem r (S.Exp f)
+parseTestExpression = (parseExpression >=> transformExpression) . unlines

--- a/src/test/HST/Util/FreeVarsTests.hs
+++ b/src/test/HST/Util/FreeVarsTests.hs
@@ -9,7 +9,7 @@ import           HST.Effect.Cancel         ( Cancel )
 import           HST.Effect.Report         ( Report )
 import           HST.Effect.SetExpectation ( SetExpectation, setExpectation )
 import           HST.Effect.WithFrontend   ( WithFrontend )
-import           HST.Frontend.Syntax       as S
+import qualified HST.Frontend.Syntax       as S
 import           HST.Test.Parser           ( parseTestModule )
 import           HST.Test.Runner           ( runTest )
 import           HST.Util.FreeVars         ( freeVars )
@@ -20,7 +20,7 @@ import           HST.Util.FreeVars         ( freeVars )
 -- | Parses the given Haskell module and sets the expectation that the given
 --   variables are free.
 shouldBeFreeIn
-  :: (Members '[Cancel, Report, SetExpectation, WithFrontend f] r, ShowAST f)
+  :: (Members '[Cancel, Report, SetExpectation, WithFrontend f] r, S.ShowAST f)
   => [String] -- ^ The identifiers of the expected free variables.
   -> [String] -- ^ The lines of the input module.
   -> Sem r ()

--- a/src/test/HST/Util/SubstTests.hs
+++ b/src/test/HST/Util/SubstTests.hs
@@ -9,8 +9,7 @@ import           HST.Effect.Report         ( Report )
 import           HST.Effect.SetExpectation ( SetExpectation )
 import           HST.Effect.WithFrontend   ( WithFrontend )
 import qualified HST.Frontend.Syntax       as S
-import           HST.Test.Expectation
-  ( prettyExpShouldBe )
+import           HST.Test.Expectation      ( prettyExpShouldBe )
 import           HST.Test.Parser           ( parseTestExp )
 import           HST.Test.Runner           ( runTest )
 import           HST.Util.Subst
@@ -316,9 +315,8 @@ testSubst = describe "HST.Util.Subst" $ do
       --          x_0 -> x_0
       --           where x_0 = y
       --                 y   = x
-      let subst    =
-            substFromList [(S.unQual y, S.var x), (S.unQual z, S.var x)]
+      let subst
+            = substFromList [(S.unQual y, S.var x), (S.unQual z, S.var x)]
           e        = "case x of { x_0 -> x   where { x   = y; y = z } }"
           expected = "case x of { x_0 -> x_0 where { x_0 = y; y = x } }"
-                     
       in shouldSubstituteTo subst e expected

--- a/src/test/HST/Util/SubstTests.hs
+++ b/src/test/HST/Util/SubstTests.hs
@@ -1,39 +1,26 @@
 -- | This module contains tests for "HST.Util.Subst".
---
---   TODO Implement expression parser.
---   The tests currently construct AST nodes manually since there is no parser
---   for expressions, yet.
 module HST.Util.SubstTests where
 
-import           Polysemy                  ( Member, Sem )
-import           Test.Hspec
-  ( Spec, context, describe, it, shouldBe )
+import           Polysemy                  ( Members, Sem )
+import           Test.Hspec                ( Spec, context, describe, it )
 
-import           HST.Effect.SetExpectation ( setExpectation )
+import           HST.Effect.Cancel         ( Cancel )
+import           HST.Effect.Report         ( Report )
+import           HST.Effect.SetExpectation ( SetExpectation )
 import           HST.Effect.WithFrontend   ( WithFrontend )
 import qualified HST.Frontend.Syntax       as S
+import           HST.Test.Expectation      ( prettyExpressionShouldBe )
+import           HST.Test.Parser           ( parseTestExpression )
 import           HST.Test.Runner           ( runTest )
 import           HST.Util.Subst
-  ( applySubst, composeSubst, singleSubst, substFromList )
+  ( Subst, applySubst, composeSubst, singleSubst, substFromList )
 
 -------------------------------------------------------------------------------
 -- Test Values                                                               --
 -------------------------------------------------------------------------------
--- | Name of a test function @f@.
-f :: S.Name a
-f = S.Ident S.NoSrcSpan "f"
-
 -- | Name of a test variable @x@.
 x :: S.Name a
 x = S.Ident S.NoSrcSpan "x"
-
--- | Name of the fresh test variable @x_0@.
-x_0 :: S.Name a
-x_0 = S.Ident S.NoSrcSpan "x_0"
-
--- | Name of the fresh test variable @x_1@.
-x_1 :: S.Name a
-x_1 = S.Ident S.NoSrcSpan "x_1"
 
 -- | Name of a test variable @y@.
 y :: S.Name a
@@ -44,15 +31,22 @@ z :: S.Name a
 z = S.Ident S.NoSrcSpan "z"
 
 -------------------------------------------------------------------------------
--- Utility Functions                                                         --
+-- Expectation Setters                                                       --
 -------------------------------------------------------------------------------
--- | Helper function that disambiguates the front end configuration type
---   variable of an AST node.
---
---   Without this helper function the 'S.ShowAST' instance that is provided by
---   the 'WithFrontend' effect cannot be used by 'shouldBe' in the tests below.
-currentFrontendSyntax :: Member (WithFrontend f) r => node f -> Sem r (node f)
-currentFrontendSyntax = return
+-- | Parses the given expressions, applies the given substitution to the first
+--   expression and sets the expectation that the given output expression is
+--   produced.
+shouldSubstituteTo
+  :: (S.EqAST f, Members '[Cancel, Report, SetExpectation, WithFrontend f] r)
+  => Subst f
+  -> [String]
+  -> [String]
+  -> Sem r ()
+shouldSubstituteTo subst input expectedOutput = do
+  inputExp <- parseTestExpression input
+  let outputExp = applySubst subst inputExp
+  expectedOutputExp <- parseTestExpression expectedOutput
+  outputExp `prettyExpressionShouldBe` expectedOutputExp
 
 -------------------------------------------------------------------------------
 -- Tests                                                                     --
@@ -61,124 +55,103 @@ currentFrontendSyntax = return
 testSubst :: Spec
 testSubst = describe "HST.Util.Subst" $ do
   context "composeSubst" $ do
-    it "applies the second substitution first" $ runTest $ do
+    it "applies the second substitution first"
+      $ runTest
+      $
       -- σ₁   = { x ↦ z }
       -- σ₂   = { x ↦ y }
       -- σ    = σ₁ . σ₂ = { x ↦ y }
       -- e    = x y z
       -- σ(e) = y y z
-      let s1    = singleSubst (S.unQual x) (S.var z)
-          s2    = singleSubst (S.unQual x) (S.var y)
-          subst = composeSubst s1 s2
-          e     = S.app S.NoSrcSpan (S.var x) [S.var y, S.var z]
-      e' <- currentFrontendSyntax $ applySubst subst e
-      expected <- currentFrontendSyntax
-        $ S.app S.NoSrcSpan (S.var y) [S.var y, S.var z]
-      setExpectation (e' `shouldBe` expected)
-    it "applies the second substitution to the first" $ runTest $ do
+      let s1       = singleSubst (S.unQual x) (S.var z)
+          s2       = singleSubst (S.unQual x) (S.var y)
+          subst    = composeSubst s1 s2
+          e        = ["x y z"]
+          expected = ["y y z"]
+      in shouldSubstituteTo subst e expected
+    it "applies the second substitution to the first"
+      $ runTest
+      $
       -- σ₁   = { y ↦ z }
       -- σ₂   = { x ↦ y }
       -- σ    = σ₁ . σ₂ = { x ↦ z, y ↦ z }
       -- e    = x y z
       -- σ(e) = z z z
-      let s1    = singleSubst (S.unQual y) (S.var z)
-          s2    = singleSubst (S.unQual x) (S.var y)
-          subst = composeSubst s1 s2
-          e     = S.app S.NoSrcSpan (S.var x) [S.var y, S.var z]
-      e' <- currentFrontendSyntax $ applySubst subst e
-      expected <- currentFrontendSyntax
-        $ S.app S.NoSrcSpan (S.var z) [S.var z, S.var z]
-      setExpectation (e' `shouldBe` expected)
+      let s1       = singleSubst (S.unQual y) (S.var z)
+          s2       = singleSubst (S.unQual x) (S.var y)
+          subst    = composeSubst s1 s2
+          e        = ["x y z"]
+          expected = ["z z z"]
+      in shouldSubstituteTo subst e expected
   context "applySubst" $ do
-    it "substitutes variables" $ runTest $ do
+    it "substitutes variables"
+      $ runTest
+      $
       -- σ    = { x ↦ y }
       -- e    = f x
       -- σ(e) = f y
-      let subst = singleSubst (S.unQual x) (S.var y)
-          e     = S.App S.NoSrcSpan (S.var f) (S.var x)
-      e' <- currentFrontendSyntax $ applySubst subst e
-      expected <- currentFrontendSyntax $ S.App S.NoSrcSpan (S.var f) (S.var y)
-      setExpectation (e' `shouldBe` expected)
-    it "does not substitute bound variables" $ runTest $ do
+      let subst    = singleSubst (S.unQual x) (S.var y)
+          e        = ["f x"]
+          expected = ["f y"]
+      in shouldSubstituteTo subst e expected
+    it "does not substitute bound variables"
+      $ runTest
+      $
       -- σ    = { x ↦ z, y ↦ z }
       -- e    = (\x -> f x y, x, y)
       -- σ(e) = (\x -> f x z, z, z)
-      let subst = substFromList [(S.unQual x, S.var z), (S.unQual y, S.var z)]
-          e     = S.Tuple S.NoSrcSpan S.Boxed
-            [ S.Lambda S.NoSrcSpan [S.PVar S.NoSrcSpan x]
-                (S.app S.NoSrcSpan (S.var f) [S.var x, S.var y])
-            , S.var x
-            , S.var y
-            ]
-      e' <- currentFrontendSyntax $ applySubst subst e
-      expected <- currentFrontendSyntax
-        $ S.Tuple S.NoSrcSpan S.Boxed
-        [ S.Lambda S.NoSrcSpan [S.PVar S.NoSrcSpan x]
-            (S.app S.NoSrcSpan (S.var f) [S.var x, S.var z])
-        , S.var z
-        , S.var z
-        ]
-      setExpectation (e' `shouldBe` expected)
-    it "renames bound variables to avoid capture" $ runTest $ do
+      let subst
+            = substFromList [(S.unQual x, S.var z), (S.unQual y, S.var z)]
+          e        = ["(\\x -> f x y, x, y)"]
+          expected = ["(\\x -> f x z, z, z)"]
+      in shouldSubstituteTo subst e expected
+    it "renames bound variables to avoid capture"
+      $ runTest
+      $
       -- σ    = { y ↦ x }
-      -- e    = \x -> (x, y)
+      -- e    = \x   -> (x, y)
       -- σ(e) = \x_0 -> (x_0, x)
-      let subst = singleSubst (S.unQual y) (S.var x)
-          e     = S.Lambda S.NoSrcSpan [S.PVar S.NoSrcSpan x]
-            (S.Tuple S.NoSrcSpan S.Boxed [S.var x, S.var y])
-      e' <- currentFrontendSyntax $ applySubst subst e
-      expected <- currentFrontendSyntax
-        $ S.Lambda S.NoSrcSpan [S.PVar S.NoSrcSpan x_0]
-        (S.Tuple S.NoSrcSpan S.Boxed [S.var x_0, S.var x])
-      setExpectation (e' `shouldBe` expected)
-    it "renames bound variables only if necessary" $ runTest $ do
+      let subst    = singleSubst (S.unQual y) (S.var x)
+          e        = ["\\x   -> (x, y)"]
+          expected = ["\\x_0 -> (x_0, x)"]
+      in shouldSubstituteTo subst e expected
+    it "renames bound variables only if necessary"
+      $ runTest
+      $
       -- σ    = { y ↦ z }
       -- e    = \x -> (x, y)
       -- σ(e) = \x -> (x, z)
-      let subst = singleSubst (S.unQual y) (S.var z)
-          e     = S.Lambda S.NoSrcSpan [S.PVar S.NoSrcSpan x]
-            (S.Tuple S.NoSrcSpan S.Boxed [S.var x, S.var y])
-      e' <- currentFrontendSyntax $ applySubst subst e
-      expected <- currentFrontendSyntax
-        $ S.Lambda S.NoSrcSpan [S.PVar S.NoSrcSpan x]
-        (S.Tuple S.NoSrcSpan S.Boxed [S.var x, S.var z])
-      setExpectation (e' `shouldBe` expected)
+      let subst    = singleSubst (S.unQual y) (S.var z)
+          e        = ["\\x -> (x, y)"]
+          expected = ["\\x -> (x, z)"]
+      in shouldSubstituteTo subst e expected
     it "does not rename bound variables that capture unused free variables"
       $ runTest
-      $ do
-        -- σ    = { x ↦ y }
-        -- e    = \y -> y
-        -- σ(e) = \y -> y
-        let subst = singleSubst (S.unQual x) (S.var y)
-            e     = S.Lambda S.NoSrcSpan [S.PVar S.NoSrcSpan y]
-              (S.Tuple S.NoSrcSpan S.Boxed [S.var y])
-        e' <- currentFrontendSyntax $ applySubst subst e
-        expected <- currentFrontendSyntax
-          $ S.Lambda S.NoSrcSpan [S.PVar S.NoSrcSpan y]
-          (S.Tuple S.NoSrcSpan S.Boxed [S.var y])
-        setExpectation (e' `shouldBe` expected)
-    it "avoids capture by renaming variables" $ runTest $ do
+      $
+      -- σ    = { x ↦ y }
+      -- e    = \y -> y
+      -- σ(e) = \y -> y
+      let subst    = singleSubst (S.unQual x) (S.var y)
+          e        = ["\\y -> y"]
+          expected = ["\\y -> y"]
+      in shouldSubstituteTo subst e expected
+    it "avoids capture by renaming variables"
+      $ runTest
+      $
       -- σ    = { y ↦ x }
       -- e    = \x   -> (x, x_0, y)
       -- σ(e) = \x_1 -> (x_1, x_0, x)
-      let subst = singleSubst (S.unQual y) (S.var x)
-          e     = S.Lambda S.NoSrcSpan [S.PVar S.NoSrcSpan x]
-            (S.Tuple S.NoSrcSpan S.Boxed [S.var x, S.var x_0, S.var y])
-      e' <- currentFrontendSyntax $ applySubst subst e
-      expected <- currentFrontendSyntax
-        $ S.Lambda S.NoSrcSpan [S.PVar S.NoSrcSpan x_1]
-        (S.Tuple S.NoSrcSpan S.Boxed [S.var x_1, S.var x_0, S.var x])
-      setExpectation (e' `shouldBe` expected)
-    it "avoids capture of renamed variables" $ runTest $ do
+      let subst    = singleSubst (S.unQual y) (S.var x)
+          e        = ["\\x   -> (x, x_0, y)"]
+          expected = ["\\x_1 -> (x_1, x_0, x)"]
+      in shouldSubstituteTo subst e expected
+    it "avoids capture of renamed variables"
+      $ runTest
+      $
       -- σ    = { y ↦ x }
       -- e    = \x   x_0 -> (x, x_0, y)
       -- σ(e) = \x_0 x_1 -> (x_0, x_1, x)
-      let subst = singleSubst (S.unQual y) (S.var x)
-          e     = S.Lambda S.NoSrcSpan
-            [S.PVar S.NoSrcSpan x, S.PVar S.NoSrcSpan x_0]
-            (S.Tuple S.NoSrcSpan S.Boxed [S.var x, S.var x_0, S.var y])
-      e' <- currentFrontendSyntax $ applySubst subst e
-      expected <- currentFrontendSyntax
-        $ S.Lambda S.NoSrcSpan [S.PVar S.NoSrcSpan x_0, S.PVar S.NoSrcSpan x_1]
-        (S.Tuple S.NoSrcSpan S.Boxed [S.var x_0, S.var x_1, S.var x])
-      setExpectation (e' `shouldBe` expected)
+      let subst    = singleSubst (S.unQual y) (S.var x)
+          e        = ["\\x   x_0 -> (x, x_0, y)"]
+          expected = ["\\x_0 x_1 -> (x_0, x_1, x)"]
+      in shouldSubstituteTo subst e expected

--- a/src/test/HST/Util/SubstTests.hs
+++ b/src/test/HST/Util/SubstTests.hs
@@ -10,8 +10,8 @@ import           HST.Effect.SetExpectation ( SetExpectation )
 import           HST.Effect.WithFrontend   ( WithFrontend )
 import qualified HST.Frontend.Syntax       as S
 import           HST.Test.Expectation
-  ( prettyExpressionShouldBe )
-import           HST.Test.Parser           ( parseTestExpression )
+  ( prettyExpShouldBe )
+import           HST.Test.Parser           ( parseTestExp )
 import           HST.Test.Runner           ( runTest )
 import           HST.Util.Subst
   ( Subst, applySubst, composeSubst, singleSubst, substFromList )
@@ -44,10 +44,10 @@ shouldSubstituteTo
   -> [String]
   -> Sem r ()
 shouldSubstituteTo subst input expectedOutput = do
-  inputExp <- parseTestExpression input
+  inputExp <- parseTestExp input
   let outputExp = applySubst subst inputExp
-  expectedOutputExp <- parseTestExpression expectedOutput
-  outputExp `prettyExpressionShouldBe` expectedOutputExp
+  expectedOutputExp <- parseTestExp expectedOutput
+  outputExp `prettyExpShouldBe` expectedOutputExp
 
 -------------------------------------------------------------------------------
 -- Tests                                                                     --

--- a/src/test/HST/Util/SubstTests.hs
+++ b/src/test/HST/Util/SubstTests.hs
@@ -9,7 +9,8 @@ import           HST.Effect.Report         ( Report )
 import           HST.Effect.SetExpectation ( SetExpectation )
 import           HST.Effect.WithFrontend   ( WithFrontend )
 import qualified HST.Frontend.Syntax       as S
-import           HST.Test.Expectation      ( prettyExpressionShouldBe, shouldTransformTo )
+import           HST.Test.Expectation
+  ( prettyExpressionShouldBe, shouldTransformTo )
 import           HST.Test.Parser           ( parseTestExpression )
 import           HST.Test.Runner           ( runTest )
 import           HST.Util.Subst
@@ -141,7 +142,8 @@ testSubst = describe "HST.Util.Subst" $ do
       $ runTest
       $
       -- σ = { x ↦ z, y ↦ z }
-      let subst    = substFromList [(S.unQual x, S.var z), (S.unQual y, S.var z)]
+      let subst
+            = substFromList [(S.unQual x, S.var z), (S.unQual y, S.var z)]
           e        = ["let x = z in x y"]
           expected = ["let x = z in x z"]
       in shouldSubstituteTo subst e expected
@@ -150,137 +152,111 @@ testSubst = describe "HST.Util.Subst" $ do
       $
       -- σ = { y ↦ z }
       let subst    = singleSubst (S.unQual y) (S.var z)
-          e        = [ "let x = let y = z in y"
-                     , "in x y"]
-          expected = [ "let x = let y = z in y"
-                     , "in x z"]
+          e        = ["let x = let y = z in y", "in x y"]
+          expected = ["let x = let y = z in y", "in x z"]
       in shouldSubstituteTo subst e expected
     it "does not substitute bound variables in nested let expressions"
       $ runTest
       $
       -- σ = { x ↦ z, y ↦ z }
-      let subst    = substFromList [(S.unQual x, S.var z), (S.unQual y, S.var z)]
-          e        = [ "let x = y"
-                     , "in let y = z in x y"]
-          expected = [ "let x = z"
-                     , "in let y = z in x y"]
+      let subst
+            = substFromList [(S.unQual x, S.var z), (S.unQual y, S.var z)]
+          e        = ["let x = y", "in let y = z in x y"]
+          expected = ["let x = z", "in let y = z in x y"]
       in shouldSubstituteTo subst e expected
     it "does not use more variable names than needed"
       $ runTest
       $
       -- σ = { y ↦ x }
       let subst    = singleSubst (S.unQual y) (S.var x)
-          e        = [ "let x = y"
-                     , "in let x = y in x"]
-          expected = [ "let x_0 = x"
-                     , "in let x_0 = x in x_0"]
+          e        = ["let x = y", "in let x = y in x"]
+          expected = ["let x_0 = x", "in let x_0 = x in x_0"]
       in shouldSubstituteTo subst e expected
     it "avoids capture by renaming variables in let expressions"
       $ runTest
       $
       -- σ = { y ↦ x, z ↦ x }
-      let subst    = substFromList [(S.unQual y, S.var x), (S.unQual z, S.var x)]
-          e        = [ "let x   = y"
-                     , "    x_0 = z"
-                     , "in  x_1"]
-          expected = [ "let x_0 = x"
-                     , "    x_2 = x"
-                     , "in  x_1"]
+      let subst
+            = substFromList [(S.unQual y, S.var x), (S.unQual z, S.var x)]
+          e        = ["let x   = y", "    x_0 = z", "in  x_1"]
+          expected = ["let x_0 = x", "    x_2 = x", "in  x_1"]
       in shouldSubstituteTo subst e expected
     it "only substitutes variables not bound by a case alternative pattern"
       $ runTest
       $
       -- σ = { x ↦ z, y ↦ z }
-      let subst    = substFromList [(S.unQual x, S.var z), (S.unQual y, S.var z)]
-          e        = [ "case x y of"
-                     , "  (x, x_0) -> (x, y)"]
-          expected = [ "case z z of"
-                     , "  (x, x_0) -> (x, z)"]
+      let subst
+            = substFromList [(S.unQual x, S.var z), (S.unQual y, S.var z)]
+          e        = ["case x y of", "  (x, x_0) -> (x, y)"]
+          expected = ["case z z of", "  (x, x_0) -> (x, z)"]
       in shouldSubstituteTo subst e expected
     it "uses different name spaces for each case alternative"
       $ runTest
       $
       -- σ = { x ↦ y }
       let subst    = singleSubst (S.unQual x) (S.var y)
-          e        = [ "case x of"
-                     , "  [y]   -> x"
-                     , "  y : z -> y : x"]
-          expected = [ "case y of"
-                     , "  [y_0]   -> y"
-                     , "  y_0 : z -> y_0 : y"]
+          e        = ["case x of", "  [y]   -> x", "  y : z -> y : x"]
+          expected = ["case y of", "  [y_0]   -> y", "  y_0 : z -> y_0 : y"]
       in shouldSubstituteTo subst e expected
     it ("only renames bound variables in case alternatives where the free "
-          ++ "variables they capture are used")
+        ++ "variables they capture are used")
       $ runTest
       $
       -- σ = { x ↦ y }
       let subst    = singleSubst (S.unQual x) (S.var y)
-          e        = [ "case x of"
-                     , "  y -> x y"
-                     , "  y -> let x = z in x y"]
-          expected = [ "case y of"
-                     , "  y_0 -> y y_0"
-                     , "  y   -> let x = z in x y"]
+          e        = ["case x of", "  y -> x y", "  y -> let x = z in x y"]
+          expected
+            = ["case y of", "  y_0 -> y y_0", "  y   -> let x = z in x y"]
       in shouldSubstituteTo subst e expected
     it "avoids capture by renaming variables in case alternative patterns"
       $ runTest
       $
       -- σ = { y ↦ x, z ↦ x }
-      let subst    = substFromList [(S.unQual y, S.var x), (S.unQual z, S.var x)]
-          e        = [ "case [y, z] of"
-                     , "  x : x_2 : x_0 -> (x, y, z)"]
-          expected = [ "case [x, x] of"
-                     , "  x_0 : x_2 : x_1 -> (x_0, x, x)"]
+      let subst
+            = substFromList [(S.unQual y, S.var x), (S.unQual z, S.var x)]
+          e        = ["case [y, z] of", "  x : x_2 : x_0 -> (x, y, z)"]
+          expected = ["case [x, x] of", "  x_0 : x_2 : x_1 -> (x_0, x, x)"]
       in shouldSubstituteTo subst e expected
     it "does not rename variables bound in where clauses"
       $ runTest
       $
       -- σ = { z ↦ x }
       let subst    = singleSubst (S.unQual z) (S.var x)
-          e        = [ "case x of"
-                     , "  y -> z"
-                     , "   where z = x"]
-          expected = [ "case x of"
-                     , "  y -> z"
-                     , "   where z = x"]
+          e        = ["case x of", "  y -> z", "   where z = x"]
+          expected = ["case x of", "  y -> z", "   where z = x"]
       in shouldSubstituteTo subst e expected
     it "only considers where clauses for their respective case alternative"
       $ runTest
       $
       -- σ = { z ↦ x }
       let subst    = singleSubst (S.unQual z) (S.var x)
-          e        = [ "case x of"
-                     , "  x -> z"
-                     , "   where z = x"
-                     , "  y -> z"]
-          expected = [ "case x of"
-                     , "  x -> z"
-                     , "   where z = x"
-                     , "  y -> x"]
+          e        = ["case x of", "  x -> z", "   where z = x", "  y -> z"]
+          expected = ["case x of", "  x -> z", "   where z = x", "  y -> x"]
       in shouldSubstituteTo subst e expected
     it "does not rename variables bound later in the where clause"
       $ runTest
       $
       -- σ = { y ↦ x, z ↦ x }
-      let subst    = substFromList [(S.unQual y, S.var x), (S.unQual z, S.var x)]
-          e        = [ "case x of"
-                     , "  x_0 -> x"
-                     , "   where x = y"
-                     , "         y = z"]
+      let subst
+            = substFromList [(S.unQual y, S.var x), (S.unQual z, S.var x)]
+          e
+            = ["case x of", "  x_0 -> x", "   where x = y", "         y = z"]
           expected = [ "case x of"
                      , "  x_0 -> x_0"
                      , "   where x_0 = y"
-                     , "         y   = x"]
+                     , "         y   = x"
+                     ]
       in shouldSubstituteTo subst e expected
   context "substitution in modules" $ do
-    it "avoids capture of variables shadowed in let expressions" $ runTest $
-      let m        = [ "module A where"
-                     , "f (x, y) = let x = y in x"]
-          expected = [ "module A where"
-                     , "f a0 = case a0 of"
-                     , "  (a1, a2) -> let x = a2 in x"]
-      in m `shouldTransformTo` expected
-{- TODO The following test should be used instead of the replacement that is
+    it "avoids capture of variables shadowed in let expressions"
+      $ runTest
+      $ let m        = ["module A where", "f (x, y) = let x = y in x"]
+            expected = [ "module A where"
+                       , "f a0 = case a0 of"
+                       , "  (a1, a2) -> let x = a2 in x"
+                       ]
+        in m `shouldTransformTo` expected
+    {- TODO The following test should be used instead of the replacement that is
         not commented out, after the corresponding issue has been fixed.
     it "avoids capture of variables shadowed in case expressions" $ runTest $
       let m        = [ "module A where"
@@ -291,16 +267,19 @@ testSubst = describe "HST.Util.Subst" $ do
                      , "  (a1, a2) -> case a1 of"
                      , "    y -> (a1, y)"]
       in m `shouldTransformTo` expected -}
-    it "avoids capture of variables shadowed in case expressions" $ runTest $
-      let m        = [ "module A where"
-                     , "f (x, y) ="
-                     , "  let r = case x of"
-                     , "            y -> (x, y)"
-                     , "  in  r"]
-          expected = [ "module A where"
-                     , "f a1 = case a1 of"
-                     , "  (a2, a3) ->"
-                     , "    let r = case a2 of"
-                     , "              a0 -> (a2, a0)"
-                     , "    in  r"]
-      in m `shouldTransformTo` expected
+    it "avoids capture of variables shadowed in case expressions"
+      $ runTest
+      $ let m        = [ "module A where"
+                       , "f (x, y) ="
+                       , "  let r = case x of"
+                       , "            y -> (x, y)"
+                       , "  in  r"
+                       ]
+            expected = [ "module A where"
+                       , "f a1 = case a1 of"
+                       , "  (a2, a3) ->"
+                       , "    let r = case a2 of"
+                       , "              a0 -> (a2, a0)"
+                       , "    in  r"
+                       ]
+        in m `shouldTransformTo` expected

--- a/src/test/HST/Util/SubstTests.hs
+++ b/src/test/HST/Util/SubstTests.hs
@@ -58,11 +58,9 @@ testSubst = describe "HST.Util.Subst" $ do
     it "applies the second substitution first"
       $ runTest
       $
-      -- σ₁   = { x ↦ z }
-      -- σ₂   = { x ↦ y }
-      -- σ    = σ₁ . σ₂ = { x ↦ y }
-      -- e    = x y z
-      -- σ(e) = y y z
+      -- σ₁ = { x ↦ z }
+      -- σ₂ = { x ↦ y }
+      -- σ  = σ₁ . σ₂ = { x ↦ y }
       let s1       = singleSubst (S.unQual x) (S.var z)
           s2       = singleSubst (S.unQual x) (S.var y)
           subst    = composeSubst s1 s2
@@ -72,11 +70,9 @@ testSubst = describe "HST.Util.Subst" $ do
     it "applies the second substitution to the first"
       $ runTest
       $
-      -- σ₁   = { y ↦ z }
-      -- σ₂   = { x ↦ y }
-      -- σ    = σ₁ . σ₂ = { x ↦ z, y ↦ z }
-      -- e    = x y z
-      -- σ(e) = z z z
+      -- σ₁ = { y ↦ z }
+      -- σ₂ = { x ↦ y }
+      -- σ  = σ₁ . σ₂ = { x ↦ z, y ↦ z }
       let s1       = singleSubst (S.unQual y) (S.var z)
           s2       = singleSubst (S.unQual x) (S.var y)
           subst    = composeSubst s1 s2
@@ -87,9 +83,7 @@ testSubst = describe "HST.Util.Subst" $ do
     it "substitutes variables"
       $ runTest
       $
-      -- σ    = { x ↦ y }
-      -- e    = f x
-      -- σ(e) = f y
+      -- σ = { x ↦ y }
       let subst    = singleSubst (S.unQual x) (S.var y)
           e        = ["f x"]
           expected = ["f y"]
@@ -97,9 +91,7 @@ testSubst = describe "HST.Util.Subst" $ do
     it "does not substitute bound variables"
       $ runTest
       $
-      -- σ    = { x ↦ z, y ↦ z }
-      -- e    = (\x -> f x y, x, y)
-      -- σ(e) = (\x -> f x z, z, z)
+      -- σ = { x ↦ z, y ↦ z }
       let subst
             = substFromList [(S.unQual x, S.var z), (S.unQual y, S.var z)]
           e        = ["(\\x -> f x y, x, y)"]
@@ -108,9 +100,7 @@ testSubst = describe "HST.Util.Subst" $ do
     it "renames bound variables to avoid capture"
       $ runTest
       $
-      -- σ    = { y ↦ x }
-      -- e    = \x   -> (x, y)
-      -- σ(e) = \x_0 -> (x_0, x)
+      -- σ = { y ↦ x }
       let subst    = singleSubst (S.unQual y) (S.var x)
           e        = ["\\x   -> (x, y)"]
           expected = ["\\x_0 -> (x_0, x)"]
@@ -118,9 +108,7 @@ testSubst = describe "HST.Util.Subst" $ do
     it "renames bound variables only if necessary"
       $ runTest
       $
-      -- σ    = { y ↦ z }
-      -- e    = \x -> (x, y)
-      -- σ(e) = \x -> (x, z)
+      -- σ = { y ↦ z }
       let subst    = singleSubst (S.unQual y) (S.var z)
           e        = ["\\x -> (x, y)"]
           expected = ["\\x -> (x, z)"]
@@ -128,9 +116,7 @@ testSubst = describe "HST.Util.Subst" $ do
     it "does not rename bound variables that capture unused free variables"
       $ runTest
       $
-      -- σ    = { x ↦ y }
-      -- e    = \y -> y
-      -- σ(e) = \y -> y
+      -- σ = { x ↦ y }
       let subst    = singleSubst (S.unQual x) (S.var y)
           e        = ["\\y -> y"]
           expected = ["\\y -> y"]
@@ -138,9 +124,7 @@ testSubst = describe "HST.Util.Subst" $ do
     it "avoids capture by renaming variables"
       $ runTest
       $
-      -- σ    = { y ↦ x }
-      -- e    = \x   -> (x, x_0, y)
-      -- σ(e) = \x_1 -> (x_1, x_0, x)
+      -- σ = { y ↦ x }
       let subst    = singleSubst (S.unQual y) (S.var x)
           e        = ["\\x   -> (x, x_0, y)"]
           expected = ["\\x_1 -> (x_1, x_0, x)"]
@@ -148,9 +132,7 @@ testSubst = describe "HST.Util.Subst" $ do
     it "avoids capture of renamed variables"
       $ runTest
       $
-      -- σ    = { y ↦ x }
-      -- e    = \x   x_0 -> (x, x_0, y)
-      -- σ(e) = \x_0 x_1 -> (x_0, x_1, x)
+      -- σ = { y ↦ x }
       let subst    = singleSubst (S.unQual y) (S.var x)
           e        = ["\\x   x_0 -> (x, x_0, y)"]
           expected = ["\\x_0 x_1 -> (x_0, x_1, x)"]

--- a/src/test/HST/Util/SubstTests.hs
+++ b/src/test/HST/Util/SubstTests.hs
@@ -40,8 +40,8 @@ z = S.Ident S.NoSrcSpan "z"
 shouldSubstituteTo
   :: (S.EqAST f, Members '[Cancel, Report, SetExpectation, WithFrontend f] r)
   => Subst f
-  -> [String]
-  -> [String]
+  -> String
+  -> String
   -> Sem r ()
 shouldSubstituteTo subst input expectedOutput = do
   inputExp <- parseTestExp input
@@ -67,8 +67,8 @@ testSubst = describe "HST.Util.Subst" $ do
       let s1       = singleSubst (S.unQual x) (S.var z)
           s2       = singleSubst (S.unQual x) (S.var y)
           subst    = composeSubst s1 s2
-          e        = ["x y z"]
-          expected = ["y y z"]
+          e        = "x y z"
+          expected = "y y z"
       in shouldSubstituteTo subst e expected
     it "applies the second substitution to the first"
       $ runTest
@@ -81,8 +81,8 @@ testSubst = describe "HST.Util.Subst" $ do
       let s1       = singleSubst (S.unQual y) (S.var z)
           s2       = singleSubst (S.unQual x) (S.var y)
           subst    = composeSubst s1 s2
-          e        = ["x y z"]
-          expected = ["z z z"]
+          e        = "x y z"
+          expected = "z z z"
       in shouldSubstituteTo subst e expected
   context "applySubst" $ do
     it "substitutes variables"
@@ -92,8 +92,8 @@ testSubst = describe "HST.Util.Subst" $ do
       -- e    = f x
       -- σ(e) = f y
       let subst    = singleSubst (S.unQual x) (S.var y)
-          e        = ["f x"]
-          expected = ["f y"]
+          e        = "f x"
+          expected = "f y"
       in shouldSubstituteTo subst e expected
     it "does not substitute bound variables"
       $ runTest
@@ -103,8 +103,8 @@ testSubst = describe "HST.Util.Subst" $ do
       -- σ(e) = (\x -> f x z, z, z)
       let subst
             = substFromList [(S.unQual x, S.var z), (S.unQual y, S.var z)]
-          e        = ["(\\x -> f x y, x, y)"]
-          expected = ["(\\x -> f x z, z, z)"]
+          e        = "(\\x -> f x y, x, y)"
+          expected = "(\\x -> f x z, z, z)"
       in shouldSubstituteTo subst e expected
     it "renames bound variables to avoid capture"
       $ runTest
@@ -113,8 +113,8 @@ testSubst = describe "HST.Util.Subst" $ do
       -- e    = \x -> (x, y)
       -- σ(e) = \x_0 -> (x_0, x)
       let subst    = singleSubst (S.unQual y) (S.var x)
-          e        = ["\\x   -> (x, y)"]
-          expected = ["\\x_0 -> (x_0, x)"]
+          e        = "\\x   -> (x, y)"
+          expected = "\\x_0 -> (x_0, x)"
       in shouldSubstituteTo subst e expected
     it "renames bound variables only if necessary"
       $ runTest
@@ -123,8 +123,8 @@ testSubst = describe "HST.Util.Subst" $ do
       -- e    = \x -> (x, y)
       -- σ(e) = \x -> (x, z)
       let subst    = singleSubst (S.unQual y) (S.var z)
-          e        = ["\\x -> (x, y)"]
-          expected = ["\\x -> (x, z)"]
+          e        = "\\x -> (x, y)"
+          expected = "\\x -> (x, z)"
       in shouldSubstituteTo subst e expected
     it "does not rename bound variables that capture unused free variables"
       $ runTest
@@ -133,8 +133,8 @@ testSubst = describe "HST.Util.Subst" $ do
       -- e    = \y -> y
       -- σ(e) = \y -> y
       let subst    = singleSubst (S.unQual x) (S.var y)
-          e        = ["\\y -> y"]
-          expected = ["\\y -> y"]
+          e        = "\\y -> y"
+          expected = "\\y -> y"
       in shouldSubstituteTo subst e expected
     it "avoids capture by renaming variables"
       $ runTest
@@ -143,8 +143,8 @@ testSubst = describe "HST.Util.Subst" $ do
       -- e    = \x   -> (x, x_0, y)
       -- σ(e) = \x_1 -> (x_1, x_0, x)
       let subst    = singleSubst (S.unQual y) (S.var x)
-          e        = ["\\x   -> (x, x_0, y)"]
-          expected = ["\\x_1 -> (x_1, x_0, x)"]
+          e        = "\\x   -> (x, x_0, y)"
+          expected = "\\x_1 -> (x_1, x_0, x)"
       in shouldSubstituteTo subst e expected
     it "avoids capture of renamed variables"
       $ runTest
@@ -153,8 +153,8 @@ testSubst = describe "HST.Util.Subst" $ do
       -- e    = \x   x_0 -> (x, x_0, y)
       -- σ(e) = \x_0 x_1 -> (x_0, x_1, x)
       let subst    = singleSubst (S.unQual y) (S.var x)
-          e        = ["\\x   x_0 -> (x, x_0, y)"]
-          expected = ["\\x_0 x_1 -> (x_0, x_1, x)"]
+          e        = "\\x   x_0 -> (x, x_0, y)"
+          expected = "\\x_0 x_1 -> (x_0, x_1, x)"
       in shouldSubstituteTo subst e expected
     it "does not substitute bound variables in let expressions"
       $ runTest
@@ -164,8 +164,8 @@ testSubst = describe "HST.Util.Subst" $ do
       -- σ(e) = let x = z in x z
       let subst
             = substFromList [(S.unQual x, S.var z), (S.unQual y, S.var z)]
-          e        = ["let x = z in x y"]
-          expected = ["let x = z in x z"]
+          e        = "let x = z in x y"
+          expected = "let x = z in x z"
       in shouldSubstituteTo subst e expected
     it "renames variables that are no longer bound"
       $ runTest
@@ -176,8 +176,8 @@ testSubst = describe "HST.Util.Subst" $ do
       -- σ(e) = let x = let y = z in y
       --        in x y
       let subst    = singleSubst (S.unQual y) (S.var z)
-          e        = ["let x = let y = z in y", "in x y"]
-          expected = ["let x = let y = z in y", "in x z"]
+          e        = "let x = let y = z in y in x y"
+          expected = "let x = let y = z in y in x z"
       in shouldSubstituteTo subst e expected
     it "does not substitute bound variables in nested let expressions"
       $ runTest
@@ -189,8 +189,8 @@ testSubst = describe "HST.Util.Subst" $ do
       --        in let y = z in x y
       let subst
             = substFromList [(S.unQual x, S.var z), (S.unQual y, S.var z)]
-          e        = ["let x = y", "in let y = z in x y"]
-          expected = ["let x = z", "in let y = z in x y"]
+          e        = "let x = y in let y = z in x y"
+          expected = "let x = z in let y = z in x y"
       in shouldSubstituteTo subst e expected
     it "does not use more variable names than needed"
       $ runTest
@@ -201,8 +201,8 @@ testSubst = describe "HST.Util.Subst" $ do
       -- σ(e) = let x_0 = x
       --        in let x_0 = x in x_0
       let subst    = singleSubst (S.unQual y) (S.var x)
-          e        = ["let x = y", "in let x = y in x"]
-          expected = ["let x_0 = x", "in let x_0 = x in x_0"]
+          e        = "let x = y in let x = y in x"
+          expected = "let x_0 = x in let x_0 = x in x_0"
       in shouldSubstituteTo subst e expected
     it "avoids capture by renaming variables in let expressions"
       $ runTest
@@ -216,8 +216,8 @@ testSubst = describe "HST.Util.Subst" $ do
       --        in  x_1
       let subst
             = substFromList [(S.unQual y, S.var x), (S.unQual z, S.var x)]
-          e        = ["let x   = y", "    x_0 = z", "in  x_1"]
-          expected = ["let x_0 = x", "    x_2 = x", "in  x_1"]
+          e        = "let { x   = y; x_0 = z } in x_1"
+          expected = "let { x_0 = x; x_2 = x } in x_1"
       in shouldSubstituteTo subst e expected
     it "only substitutes variables not bound by a case alternative pattern"
       $ runTest
@@ -229,8 +229,8 @@ testSubst = describe "HST.Util.Subst" $ do
       --          (x, x_0) -> (x, z)
       let subst
             = substFromList [(S.unQual x, S.var z), (S.unQual y, S.var z)]
-          e        = ["case x y of", "  (x, x_0) -> (x, y)"]
-          expected = ["case z z of", "  (x, x_0) -> (x, z)"]
+          e        = "case x y of { (x, x_0) -> (x, y) }"
+          expected = "case z z of { (x, x_0) -> (x, z) }"
       in shouldSubstituteTo subst e expected
     it "uses different name spaces for each case alternative"
       $ runTest
@@ -243,8 +243,8 @@ testSubst = describe "HST.Util.Subst" $ do
       --          [y_0]   -> y
       --          y_0 : z -> y_0 : y
       let subst    = singleSubst (S.unQual x) (S.var y)
-          e        = ["case x of", "  [y]   -> x", "  y : z -> y : x"]
-          expected = ["case y of", "  [y_0]   -> y", "  y_0 : z -> y_0 : y"]
+          e        = "case x of { [y]   -> x; y   : z -> y   : x }"
+          expected = "case y of { [y_0] -> y; y_0 : z -> y_0 : y }"
       in shouldSubstituteTo subst e expected
     it ("only renames bound variables in case alternatives where the free "
         ++ "variables they capture are used")
@@ -258,9 +258,8 @@ testSubst = describe "HST.Util.Subst" $ do
       --          y_0 -> y y_0
       --          y   -> let x = z in x y
       let subst    = singleSubst (S.unQual x) (S.var y)
-          e        = ["case x of", "  y -> x y", "  y -> let x = z in x y"]
-          expected
-            = ["case y of", "  y_0 -> y y_0", "  y   -> let x = z in x y"]
+          e        = "case x of { y   -> x y  ; y -> let x = z in x y }"
+          expected = "case y of { y_0 -> y y_0; y -> let x = z in x y }"
       in shouldSubstituteTo subst e expected
     it "avoids capture by renaming variables in case alternative patterns"
       $ runTest
@@ -272,8 +271,8 @@ testSubst = describe "HST.Util.Subst" $ do
       --          x_0 : x_2 : x_1 -> (x_0, x, x)
       let subst
             = substFromList [(S.unQual y, S.var x), (S.unQual z, S.var x)]
-          e        = ["case [y, z] of", "  x : x_2 : x_0 -> (x, y, z)"]
-          expected = ["case [x, x] of", "  x_0 : x_2 : x_1 -> (x_0, x, x)"]
+          e        = "case [y, z] of { x   : x_2 : x_0 -> (x  , y, z) }"
+          expected = "case [x, x] of { x_0 : x_2 : x_1 -> (x_0, x, x) }"
       in shouldSubstituteTo subst e expected
     it "does not rename variables bound in where clauses"
       $ runTest
@@ -286,8 +285,8 @@ testSubst = describe "HST.Util.Subst" $ do
       --          y -> z
       --           where z = x
       let subst    = singleSubst (S.unQual z) (S.var x)
-          e        = ["case x of", "  y -> z", "   where z = x"]
-          expected = ["case x of", "  y -> z", "   where z = x"]
+          e        = "case x of { y -> z where z = x }"
+          expected = "case x of { y -> z where z = x }"
       in shouldSubstituteTo subst e expected
     it "only considers where clauses for their respective case alternative"
       $ runTest
@@ -302,8 +301,8 @@ testSubst = describe "HST.Util.Subst" $ do
       --           where z = x
       --          y -> x
       let subst    = singleSubst (S.unQual z) (S.var x)
-          e        = ["case x of", "  x -> z", "   where z = x", "  y -> z"]
-          expected = ["case x of", "  x -> z", "   where z = x", "  y -> x"]
+          e        = "case x of { x -> z where { z = x }; y -> z }"
+          expected = "case x of { x -> z where { z = x }; y -> x }"
       in shouldSubstituteTo subst e expected
     it "does not rename variables bound later in the where clause"
       $ runTest
@@ -317,13 +316,9 @@ testSubst = describe "HST.Util.Subst" $ do
       --          x_0 -> x_0
       --           where x_0 = y
       --                 y   = x
-      let subst
-            = substFromList [(S.unQual y, S.var x), (S.unQual z, S.var x)]
-          e
-            = ["case x of", "  x_0 -> x", "   where x = y", "         y = z"]
-          expected = [ "case x of"
-                     , "  x_0 -> x_0"
-                     , "   where x_0 = y"
-                     , "         y   = x"
-                     ]
+      let subst    =
+            substFromList [(S.unQual y, S.var x), (S.unQual z, S.var x)]
+          e        = "case x of { x_0 -> x   where { x   = y; y = z } }"
+          expected = "case x of { x_0 -> x_0 where { x_0 = y; y = x } }"
+                     
       in shouldSubstituteTo subst e expected

--- a/src/test/HST/Util/SubstTests.hs
+++ b/src/test/HST/Util/SubstTests.hs
@@ -10,7 +10,7 @@ import           HST.Effect.SetExpectation ( SetExpectation )
 import           HST.Effect.WithFrontend   ( WithFrontend )
 import qualified HST.Frontend.Syntax       as S
 import           HST.Test.Expectation
-  ( prettyExpressionShouldBe, shouldTransformTo )
+  ( prettyExpressionShouldBe )
 import           HST.Test.Parser           ( parseTestExpression )
 import           HST.Test.Runner           ( runTest )
 import           HST.Util.Subst
@@ -327,39 +327,3 @@ testSubst = describe "HST.Util.Subst" $ do
                      , "         y   = x"
                      ]
       in shouldSubstituteTo subst e expected
-  context "substitution in modules" $ do
-    it "avoids capture of variables shadowed in let expressions"
-      $ runTest
-      $ let m        = ["module A where", "f (x, y) = let x = y in x"]
-            expected = [ "module A where"
-                       , "f a0 = case a0 of"
-                       , "  (a1, a2) -> let x = a2 in x"
-                       ]
-        in m `shouldTransformTo` expected
-    {- TODO The following test should be used instead of the replacement that
-        is not commented out, after the corresponding issue has been fixed.
-    it "avoids capture of variables shadowed in case expressions" $ runTest $
-      let m        = [ "module A where"
-                     , "f (x, y) = case x of"
-                     , "             y -> (x, y)"]
-          expected = [ "module A where"
-                     , "f a0 = case a0 of"
-                     , "  (a1, a2) -> case a1 of"
-                     , "    y -> (a1, y)"]
-      in m `shouldTransformTo` expected -}
-    it "avoids capture of variables shadowed in case expressions"
-      $ runTest
-      $ let m        = [ "module A where"
-                       , "f (x, y) ="
-                       , "  let r = case x of"
-                       , "            y -> (x, y)"
-                       , "  in  r"
-                       ]
-            expected = [ "module A where"
-                       , "f a1 = case a1 of"
-                       , "  (a2, a3) ->"
-                       , "    let r = case a2 of"
-                       , "              a0 -> (a2, a0)"
-                       , "    in  r"
-                       ]
-        in m `shouldTransformTo` expected


### PR DESCRIPTION
### Issue
Closes #16.

### Description of the Change
* A parser for expressions is added, which can be used similarly to the existing module parser.
* Further test cases for the new `HST.Util.Subst` module have been added, primarily testing `let` and `case` expressions and `where` clauses. They are using the new expression parser.
* The already existing tests for the `HST.Util.Subst` module have been adapted to use the new expression parser.

### Possible Drawbacks
The expression parser is implemented in the main modules of the pattern matching compiler, but is currently only used in tests. I chose this approach so I could use the existing framework (for example the `WithFrontend` effect).