### PR TITLE
Add linter rules to restrict usage of `NoSrcSpan`

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -30,7 +30,7 @@
     - HST.Feature.GuardElimination
       # The `NoSrcSpan` constructor is allowed in its definition.
     - HST.Frontend.Syntax
-      # Entries for predefined data types and their data types don't have
+      # Entries for predefined data types and their constructors don't have
       # source spans.
     - HST.Environment.Prelude
       # We could remove the actions of the `Fresh` effect that insert

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -41,9 +41,6 @@
     # to the original AST data type.
     - HST.Frontend.GHC.To
     - HST.Frontend.HSE.To
-    # For now, we also allow `S.NoSrcSpan`s in the transformation from GHC-lib
-    # such that the pipeline passes but they should be removed.
-    - HST.Frontend.GHC.From
 
 # Aliases for qualified imports.
 - modules:

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -17,6 +17,34 @@
 # Duplication makes the test code easier to read.
 - ignore: {name: "Reduce duplication", within: ["HST.Effect.ReportTests"]}
 
+# Warn about usage of `NoSrcSpan`.
+- functions:
+  - name: [ NoSrcSpan ]
+    message: |
+      Avoid `NoSrcSpan`. Try to annotate all source spans explicitly or
+      add an exception to the `.hlint.yaml` file for this module.
+    within:
+      # Many artificial nodes are generated in the core algorithm and during
+      # guard elimination. There is not a good source span for all of them.
+    - HST.CoreAlgorithm
+    - HST.Feature.GuardElimination
+      # The `NoSrcSpan` constructor is allowed in its definition.
+    - HST.Frontend.Syntax
+      # Entries for predefined data types and their data types don't have
+      # source spans.
+    - HST.Environment.Prelude
+      # We could remove the actions of the `Fresh` effect that insert
+      # `NoSrcSpan` such that users of the effect are forced to discard
+      # location information explicitly.
+    - HST.Effect.Fresh
+    # During the back-transformation, missing source spans have to be converted
+    # to the original AST data type.
+    - HST.Frontend.GHC.To
+    - HST.Frontend.HSE.To
+    # For now, we also allow `S.NoSrcSpan`s in the transformation from GHC-lib
+    # such that the pipeline passes but they should be removed.
+    - HST.Frontend.GHC.From
+
 # Aliases for qualified imports.
 - modules:
   - {name: [ Data.Map.Strict ], as: Map}

--- a/haskell-src-transformations.cabal
+++ b/haskell-src-transformations.cabal
@@ -99,6 +99,7 @@ library
                     , HST.Frontend.GHC.Config
                     , HST.Frontend.GHC.From
                     , HST.Frontend.GHC.To
+                    , HST.Frontend.GHC.Util.AnyMatch
                     , HST.Frontend.HSE.Config
                     , HST.Frontend.HSE.From
                     , HST.Frontend.HSE.To

--- a/src/lib/HST/Application.hs
+++ b/src/lib/HST/Application.hs
@@ -18,7 +18,7 @@ import           HST.Environment
   ( ConEntry(..), DataEntry(..), insertConEntry, insertDataEntry )
 import           HST.Environment.Prelude      ( insertPreludeEntries )
 import           HST.Feature.CaseCompletion   ( applyCCModule )
-import           HST.Feature.GuardElimination ( applyGEModule, getMatchName )
+import           HST.Feature.GuardElimination ( applyGEModule )
 import           HST.Feature.Optimization     ( optimize )
 import qualified HST.Frontend.Syntax          as S
 import           HST.Options                  ( optOptimizeCase )
@@ -75,8 +75,7 @@ useAlgoMatches s ms  = useAlgo s ms
 -- | Tests whether the given match of a function declaration contains
 --   a constructor pattern.
 hasCons :: S.Match a -> Bool
-hasCons (S.Match _ _ ps _ _)         = any isConPat ps
-hasCons (S.InfixMatch _ p1 _ ps _ _) = any isConPat (p1 : ps)
+hasCons = any isConPat . S.matchPats
 
 -- | Like 'useAlgoMatches' but applies the algorithm unconditionally.
 useAlgo :: (Members '[Env a, Fresh, GetOpt, Report] r, S.EqAST a)
@@ -85,23 +84,21 @@ useAlgo :: (Members '[Env a, Fresh, GetOpt, Report] r, S.EqAST a)
         -> Sem r (S.Match a)
 useAlgo s ms = do
   eqs <- mapM matchToEquation ms
-  let name  = getMatchName (head ms)
-      arity = length (fst (head eqs))
+  let name    = S.matchName (head ms)
+      arity   = length (fst (head eqs))
+      isInfix = all S.matchIsInfix ms
   nVars <- replicateM arity (freshVarPat genericFreshPrefix)
   nExp <- match nVars eqs defaultErrorExp
   nExp' <- ifM (getOpt optOptimizeCase) (optimize nExp) (return nExp)
-  return $ S.Match s name nVars (S.UnGuardedRhs s nExp') Nothing
+  return $ S.Match s isInfix name nVars (S.UnGuardedRhs s nExp') Nothing
  where
   -- | Converts a rule of a function declaration to an equation.
   --
   --   There must be no guards on the right-hand side.
   matchToEquation :: Member Report r => S.Match a -> Sem r (Eqs a)
-  matchToEquation (S.Match _ _ pats rhs _)          = do
+  matchToEquation (S.Match _ _ _ pats rhs _) = do
     expr <- expFromUnguardedRhs rhs
     return (pats, expr)
-  matchToEquation (S.InfixMatch _ pat _ pats rhs _) = do
-    expr <- expFromUnguardedRhs rhs
-    return (pat : pats, expr)
 
 -------------------------------------------------------------------------------
 -- Environment Initialization                                                --

--- a/src/lib/HST/Application.hs
+++ b/src/lib/HST/Application.hs
@@ -118,7 +118,7 @@ collectDataInfo (S.Module _ _ _ decls) = mapM_ collectDataDecl decls
 --   data type declaration.
 collectDataDecl :: Member (Env a) r => S.Decl a -> Sem r ()
 collectDataDecl (S.DataDecl _ _ dataName conDecls) = do
-  let dataQName  = S.UnQual S.NoSrcSpan dataName
+  let dataQName  = S.unQual dataName
       conEntries = map (makeConEntry dataQName) conDecls
   modifyEnv
     $ insertDataEntry DataEntry { dataEntryName = dataQName
@@ -130,7 +130,7 @@ collectDataDecl _ = return ()
 -- | Creates an environment entry for a constructor declaration.
 makeConEntry :: S.QName a -> S.ConDecl a -> ConEntry a
 makeConEntry dataQName conDecl = ConEntry
-  { conEntryName    = S.UnQual S.NoSrcSpan (S.conDeclName conDecl)
+  { conEntryName    = S.unQual (S.conDeclName conDecl)
   , conEntryArity   = S.conDeclArity conDecl
   , conEntryIsInfix = S.conDeclIsInfix conDecl
   , conEntryType    = dataQName

--- a/src/lib/HST/Feature/CaseCompletion.hs
+++ b/src/lib/HST/Feature/CaseCompletion.hs
@@ -123,12 +123,9 @@ applyCCMatches insideLet = mapM applyCCMatch
   applyCCMatch :: (Members '[Env a, Fresh, GetOpt, Report] r, S.EqAST a)
                => S.Match a
                -> Sem r (S.Match a)
-  applyCCMatch (S.Match s n ps rhs _)        = do
-    e <- expFromUnguardedRhs rhs
-    x <- completeCase insideLet e
-    return $ S.Match s n ps (S.UnGuardedRhs (S.getSrcSpan rhs) x) Nothing
-  applyCCMatch (S.InfixMatch s p n ps rhs _) = do
-    e <- expFromUnguardedRhs rhs
-    x <- completeCase insideLet e
-    return
-      $ S.InfixMatch s p n ps (S.UnGuardedRhs (S.getSrcSpan rhs) x) Nothing
+  applyCCMatch m = do
+    let rhs     = S.matchRhs m
+        srcSpan = S.getSrcSpan rhs
+    expr <- expFromUnguardedRhs rhs
+    expr' <- completeCase insideLet expr
+    return $ m { S.matchRhs = S.UnGuardedRhs srcSpan expr' }

--- a/src/lib/HST/Feature/GuardElimination.hs
+++ b/src/lib/HST/Feature/GuardElimination.hs
@@ -59,12 +59,11 @@ generateLet vs err gExps = do
 
 -- | Creates a function declaration for a @let@ binding that binds a variable
 --   with the given name to the given expression.
---
---   TODO Maybe we can use the source span of the expression for the
---   declaration, match and right-hand side.
 makeVarBinding :: S.Name a -> S.Exp a -> S.Decl a
-makeVarBinding name expr = S.FunBind S.NoSrcSpan
-  [S.Match S.NoSrcSpan name [] (S.UnGuardedRhs S.NoSrcSpan expr) Nothing]
+makeVarBinding name expr
+  = let srcSpan = S.getSrcSpan expr
+    in S.FunBind srcSpan
+       [S.Match srcSpan name [] (S.UnGuardedRhs srcSpan expr) Nothing]
 
 -------------------------------------------------------------------------------
 -- @case@ Expressions                                                        --

--- a/src/lib/HST/Feature/GuardElimination.hs
+++ b/src/lib/HST/Feature/GuardElimination.hs
@@ -59,6 +59,9 @@ generateLet vs err gExps = do
 
 -- | Creates a function declaration for a @let@ binding that binds a variable
 --   with the given name to the given expression.
+--
+--   TODO Maybe we can use the source span of the expression for the
+--   declaration, match and right-hand side.
 makeVarBinding :: S.Name a -> S.Exp a -> S.Decl a
 makeVarBinding name expr = S.FunBind S.NoSrcSpan
   [S.Match S.NoSrcSpan name [] (S.UnGuardedRhs S.NoSrcSpan expr) Nothing]

--- a/src/lib/HST/Frontend/GHC/From.hs
+++ b/src/lib/HST/Frontend/GHC/From.hs
@@ -597,5 +597,4 @@ transformSrcSpan = S.SrcSpan
 --   all characters within the individual spans.
 combineSrcSpans :: [S.SrcSpan GHC] -> S.SrcSpan GHC
 combineSrcSpans = transformSrcSpan
-  . foldr GHC.combineSrcSpans GHC.noSrcSpan
-  . map S.originalSrcSpan
+  . foldr (GHC.combineSrcSpans . S.originalSrcSpan) GHC.noSrcSpan

--- a/src/lib/HST/Frontend/GHC/From.hs
+++ b/src/lib/HST/Frontend/GHC/From.hs
@@ -75,10 +75,14 @@ transformDecl (GHC.L s (GHC.ValD _ fb@GHC.FunBind {})) = do
     = case GHC.mc_strictness ctxt of
       GHC.NoSrcStrict -> do
         name' <- transformRdrNameUnqual (GHC.mc_fun ctxt)
-        case GHC.mc_fixity ctxt of
-          GHC.Prefix -> return $ S.Match s' name' pats' rhs' mBinds'
-          GHC.Infix  -> return
-            $ S.InfixMatch s' (head pats') name' (tail pats') rhs' mBinds'
+        return
+          $ S.Match { S.matchSrcSpan = s'
+                    , S.matchName    = name'
+                    , S.matchIsInfix = GHC.mc_fixity ctxt == GHC.Infix
+                    , S.matchPats    = pats'
+                    , S.matchRhs     = rhs'
+                    , S.matchBinds   = mBinds'
+                    }
       _               ->
         notSupported "Function declarations with strictness annotations"
   funMatchToMatch (AnyMatch _ _ _ _ _)

--- a/src/lib/HST/Frontend/GHC/From.hs
+++ b/src/lib/HST/Frontend/GHC/From.hs
@@ -25,6 +25,7 @@ import           HST.Effect.Report
 import           HST.Frontend.GHC.Config
   ( DeclWrapper(Decl), GHC, LitWrapper(Lit, OverLit)
   , OriginalModuleHead(OriginalModuleHead), TypeWrapper(SigType) )
+import           HST.Frontend.GHC.Util.AnyMatch
 import qualified HST.Frontend.Syntax               as S
 import           HST.Frontend.Transformer.Messages
   ( notSupported, skipNotSupported )
@@ -63,8 +64,25 @@ transformDecl decl@(GHC.L s (GHC.TyClD _ dataDecl@GHC.DataDecl {})) = do
       name <- transformRdrNameUnqual (GHC.tcdLName dataDecl)
       return $ S.DataDecl (transformSrcSpan s) (Decl decl) name dataDefn
 -- Function declarations are supported.
-transformDecl (GHC.L s (GHC.ValD _ fb@GHC.FunBind {}))
-  = S.FunBind (transformSrcSpan s) <$> transformMatchGroup (GHC.fun_matches fb)
+transformDecl (GHC.L s (GHC.ValD _ fb@GHC.FunBind {})) = do
+  anyMatches' <- transformMatchGroup (GHC.fun_matches fb)
+  matches' <- mapM funMatchToMatch anyMatches'
+  return $ S.FunBind (transformSrcSpan s) matches'
+ where
+  -- | Completes the translation of a match for a function declaration.
+  funMatchToMatch :: Member Report r => AnyMatch -> Sem r (S.Match GHC)
+  funMatchToMatch (AnyMatch s' ctxt@GHC.FunRhs {} pats' rhs' mBinds')
+    = case GHC.mc_strictness ctxt of
+      GHC.NoSrcStrict -> do
+        name' <- transformRdrNameUnqual (GHC.mc_fun ctxt)
+        case GHC.mc_fixity ctxt of
+          GHC.Prefix -> return $ S.Match s' name' pats' rhs' mBinds'
+          GHC.Infix  -> return
+            $ S.InfixMatch s' (head pats') name' (tail pats') rhs' mBinds'
+      _               ->
+        notSupported "Function declarations with strictness annotations"
+  funMatchToMatch (AnyMatch _ _ _ _ _)
+    = notSupported "Non-function matches in function declarations"
 -- Type and data families, type declarations, type classes and extension
 -- declarations are not supported and therefore skipped. The user is explicitly
 -- informed about skipped type classes since they might contain pattern
@@ -222,34 +240,29 @@ transformValBinds (GHC.ValBinds _ binds sigs) = mapM transformDecl
 transformValBinds (GHC.XValBindsLR _)
   = notSupported "Value bindings extensions"
 
--- | Transforms a GHC match group into HST matches.
+-- | Transforms a GHC match group into HST matches without transforming the
+--   match context.
 transformMatchGroup :: Member Report r
                     => GHC.MatchGroup GHC.GhcPs (GHC.LHsExpr GHC.GhcPs)
-                    -> Sem r [S.Match GHC]
+                    -> Sem r [AnyMatch]
 transformMatchGroup GHC.MG { GHC.mg_alts = GHC.L _ matches }
   = mapM transformMatch matches
 transformMatchGroup (GHC.XMatchGroup x) = GHC.noExtCon x
 
--- | Transforms a GHC located match into an HST match.
+-- | Transforms a GHC located match into an HST match without transforming the
+--   match context.
 transformMatch :: Member Report r
                => GHC.LMatch GHC.GhcPs (GHC.LHsExpr GHC.GhcPs)
-               -> Sem r (S.Match GHC)
+               -> Sem r AnyMatch
 transformMatch (GHC.L s match@GHC.Match {}) = do
-  let s' = transformSrcSpan s
-  (name', fixity) <- case GHC.m_ctxt match of
-    ctxt@GHC.FunRhs {} -> do
-      name <- transformRdrNameUnqual (GHC.mc_fun ctxt)
-      return (name, GHC.mc_fixity ctxt)
-    -- TODO we should change the return type of this function such that the
-    -- function name is optional. We could also remove the name from the
-    -- `S.Match` and `S.InfixMatch` constructors of the AST and move it to
-    -- `S.FunBind` instead.
-    _                  -> return $ (S.Ident S.NoSrcSpan "", GHC.Prefix)
   pats <- mapM transformPat (GHC.m_pats match)
   (rhs, mBinds) <- transformGRHSs (GHC.m_grhss match)
-  return $ case fixity of
-    GHC.Prefix -> S.Match s' name' pats rhs mBinds
-    GHC.Infix  -> S.InfixMatch s' (head pats) name' (tail pats) rhs mBinds
+  return AnyMatch { anyMatchSrcSpan  = transformSrcSpan s
+                  , anyMatchContext  = GHC.m_ctxt match
+                  , anyMatchPatterns = pats
+                  , anyMatchRhs      = rhs
+                  , anyMatchBinds    = mBinds
+                  }
 transformMatch (GHC.L _ (GHC.XMatch x))     = GHC.noExtCon x
 
 -- | Transforms GHC guarded right-hand sides into an HST right-hand side and
@@ -343,17 +356,18 @@ transformExpr (GHC.L s (GHC.HsApp _ e1 e2))
 transformExpr (GHC.L s (GHC.NegApp _ e _)) = S.NegApp (transformSrcSpan s)
   <$> transformExpr e
 transformExpr (GHC.L s (GHC.HsLam _ mg)) = do
+  let s' = transformSrcSpan s
   mg' <- transformMatchGroup mg
   case mg' of
-    [S.Match _ _ pats (S.UnGuardedRhs _ e) Nothing] -> return
-      $ S.Lambda (transformSrcSpan s) pats e
-    [ S.Match _ _ _ _ (Just _)
+    [ AnyMatch _ GHC.LambdaExpr pats' (S.UnGuardedRhs _ e') Nothing
+      ] -> return $ S.Lambda s' pats' e'
+    [ AnyMatch _ GHC.LambdaExpr _ _ (Just _)
       ] -> notSupported "Lambda abstractions with bindings"
-    [ S.Match _ _ _ (S.GuardedRhss _ _) _
+    [ AnyMatch _ GHC.LambdaExpr _ (S.GuardedRhss _ _) _
       ] -> notSupported "Lambda abstractions with guards"
-    [S.InfixMatch _ _ _ _ _ _] -> notSupported "Infix lambda abstractions"
     [] -> notSupported "Empty lambda abstractions"
-    (_ : _ : _) -> notSupported "Lambda abstractions with multiple matches"
+    [_] -> notSupported "Non-lambda matches in lambda expressions"
+    _ -> notSupported "Lambda abstractions with multiple matches"
 transformExpr (GHC.L s (GHC.HsLet _ binds e)) = do
   mBinds <- transformLocalBinds binds
   case mBinds of
@@ -369,12 +383,16 @@ transformExpr (GHC.L s (GHC.HsCase _ e mg)) = do
   alts <- mapM matchToAlt mg'
   return $ S.Case (transformSrcSpan s) e' alts
  where
-  matchToAlt :: Member Report r => S.Match GHC -> Sem r (S.Alt GHC)
-  matchToAlt (S.Match s' _ [pat] rhs mBinds) = return $ S.Alt s' pat rhs mBinds
-  matchToAlt (S.Match _ _ _ _ _)
-    = notSupported "Case alternatives without exactly one pattern"
-  matchToAlt (S.InfixMatch _ _ _ _ _ _)
-    = notSupported "Infix matches in case alternatives"
+  -- | Completes the transformation of a match to an alternative.
+  matchToAlt :: Member Report r => AnyMatch -> Sem r (S.Alt GHC)
+  matchToAlt (AnyMatch s' GHC.CaseAlt [pat'] rhs' mBinds')
+    = return $ S.Alt s' pat' rhs' mBinds'
+  matchToAlt (AnyMatch _ GHC.CaseAlt [] _ _)
+    = notSupported "Case alternatives without patterns"
+  matchToAlt (AnyMatch _ GHC.CaseAlt _ _ _)
+    = notSupported "Case alternatives with multiple patterns"
+  matchToAlt (AnyMatch _ _ _ _ _)
+    = notSupported "Non-case expression matches in case expressions"
 transformExpr (GHC.L s (GHC.ExplicitTuple _ tArgs boxity)) = S.Tuple
   (transformSrcSpan s) (transformBoxity boxity)
   <$> mapM transformTupleArg tArgs

--- a/src/lib/HST/Frontend/GHC/From.hs
+++ b/src/lib/HST/Frontend/GHC/From.hs
@@ -240,6 +240,10 @@ transformMatch (GHC.L s match@GHC.Match {}) = do
     ctxt@GHC.FunRhs {} -> do
       name <- transformRdrNameUnqual (GHC.mc_fun ctxt)
       return (name, GHC.mc_fixity ctxt)
+    -- TODO we should change the return type of this function such that the
+    -- function name is optional. We could also remove the name from the
+    -- `S.Match` and `S.InfixMatch` constructors of the AST and move it to
+    -- `S.FunBind` instead.
     _                  -> return $ (S.Ident S.NoSrcSpan "", GHC.Prefix)
   pats <- mapM transformPat (GHC.m_pats match)
   (rhs, mBinds) <- transformGRHSs (GHC.m_grhss match)
@@ -261,6 +265,7 @@ transformGRHSs grhss@GHC.GRHSs {} = do
       return (S.UnGuardedRhs (transformSrcSpan s) body', binds)
     grhss' -> do
       grhss'' <- mapM transformGRHS grhss'
+      -- TODO Can we merge the source spans of multiple right-hand sides?
       return (S.GuardedRhss S.NoSrcSpan grhss'', binds)
         -- The source span here seems to be missing in the GHC AST
 transformGRHSs (GHC.XGRHSs x)     = GHC.noExtCon x

--- a/src/lib/HST/Frontend/GHC/From.hs
+++ b/src/lib/HST/Frontend/GHC/From.hs
@@ -25,7 +25,7 @@ import           HST.Effect.Report
 import           HST.Frontend.GHC.Config
   ( DeclWrapper(Decl), GHC, LitWrapper(Lit, OverLit)
   , OriginalModuleHead(OriginalModuleHead), TypeWrapper(SigType) )
-import           HST.Frontend.GHC.Util.AnyMatch
+import           HST.Frontend.GHC.Util.AnyMatch    ( AnyMatch(..) )
 import qualified HST.Frontend.Syntax               as S
 import           HST.Frontend.Transformer.Messages
   ( notSupported, skipNotSupported )

--- a/src/lib/HST/Frontend/GHC/From.hs
+++ b/src/lib/HST/Frontend/GHC/From.hs
@@ -280,7 +280,6 @@ transformGRHSs grhss@GHC.GRHSs {} = do
       grhss'' <- mapM transformGRHS grhss'
       let srcSpan = combineSrcSpans (map S.getSrcSpan grhss'')
       return (S.GuardedRhss srcSpan grhss'', binds)
-        -- The source span here seems to be missing in the GHC AST
 transformGRHSs (GHC.XGRHSs x)     = GHC.noExtCon x
 
 -- | Transforms a GHC guarded right-hand side into an HST guarded right-hand

--- a/src/lib/HST/Frontend/GHC/To.hs
+++ b/src/lib/HST/Frontend/GHC/To.hs
@@ -149,8 +149,8 @@ transformMaybeBinds (Just (S.BDecls s decls)) = do
         ++ "retransformation. Only function and signature declarations are "
         ++ "allowed!"
 
--- | Creates a located GHC match group with the given source span that contains
---   the given matches.
+-- | Creates a GHC match group with the given source span that contains the
+--   given matches.
 makeMatchGroup :: GHC.SrcSpan
                -> [GHC.LMatch GHC.GhcPs (GHC.LHsExpr GHC.GhcPs)]
                -> GHC.MatchGroup GHC.GhcPs (GHC.LHsExpr GHC.GhcPs)

--- a/src/lib/HST/Frontend/GHC/To.hs
+++ b/src/lib/HST/Frontend/GHC/To.hs
@@ -9,17 +9,18 @@
 --   expressions.
 module HST.Frontend.GHC.To where
 
-import qualified Bag                     as GHC
-import qualified BasicTypes              as GHC
-import qualified DataCon                 as GHC
-import qualified GHC.Hs                  as GHC
-import qualified Module                  as GHC
-import qualified Name                    as GHC
-import           Polysemy                ( Member, Sem )
-import qualified RdrName                 as GHC
-import qualified SrcLoc                  as GHC
-import qualified TcEvidence              as GHC
-import qualified TysWiredIn              as GHC
+import qualified Bag                            as GHC
+import qualified BasicTypes                     as GHC
+import           Control.Monad                  ( (>=>) )
+import qualified DataCon                        as GHC
+import qualified GHC.Hs                         as GHC
+import qualified Module                         as GHC
+import qualified Name                           as GHC
+import           Polysemy                       ( Member, Sem )
+import qualified RdrName                        as GHC
+import qualified SrcLoc                         as GHC
+import qualified TcEvidence                     as GHC
+import qualified TysWiredIn                     as GHC
 
 import           HST.Effect.Report
   ( Message(Message), Report, Severity(Internal), reportFatal )
@@ -29,7 +30,8 @@ import           HST.Frontend.GHC.Config
                    originalModuleImports, originalModuleDeprecMessage,
                    originalModuleHaddockModHeader)
   , TypeWrapper(SigType) )
-import qualified HST.Frontend.Syntax     as S
+import           HST.Frontend.GHC.Util.AnyMatch
+import qualified HST.Frontend.Syntax            as S
 
 -------------------------------------------------------------------------------
 -- Modules                                                                   --
@@ -61,19 +63,20 @@ transformModule (S.Module s omh _ decls) = do
 -- | Transforms an HST declaration into an GHC located declaration.
 transformDecl :: Member Report r => S.Decl GHC -> Sem r (GHC.LHsDecl GHC.GhcPs)
 transformDecl (S.DataDecl _ (Decl oDecl) _ _) = return oDecl
-transformDecl (S.FunBind s matches) = do
+transformDecl (S.FunBind funSrcSpan matches) = do
   matchesName <- getMatchesName matches
-  let funId = transformName GHC.varName matchesName
-      s'    = transformSrcSpan s
-  matches' <- transformMatches Function s' matches
+  let funId       = transformName GHC.varName matchesName
+      funSrcSpan' = transformSrcSpan funSrcSpan
+  matches' <- mapM (matchToFunMatch >=> transformMatch) matches
   return
-    $ GHC.L s' (GHC.ValD GHC.NoExtField GHC.FunBind
-                { GHC.fun_ext     = GHC.NoExtField
-                , GHC.fun_id      = funId
-                , GHC.fun_matches = matches'
-                , GHC.fun_co_fn   = GHC.WpHole
-                , GHC.fun_tick    = []
-                })
+    $ GHC.L funSrcSpan'
+    (GHC.ValD GHC.NoExtField GHC.FunBind
+     { GHC.fun_ext     = GHC.NoExtField
+     , GHC.fun_id      = funId
+     , GHC.fun_matches = makeMatchGroup funSrcSpan' matches'
+     , GHC.fun_co_fn   = GHC.WpHole
+     , GHC.fun_tick    = []
+     })
  where
   getMatchesName :: Member Report r => [S.Match GHC] -> Sem r (S.Name GHC)
   getMatchesName (S.Match _ name _ _ _ : _) = return name
@@ -81,6 +84,36 @@ transformDecl (S.FunBind s matches) = do
   getMatchesName [] = reportFatal
     $ Message Internal
     "Encountered empty match group in function binding during retransformation!"
+
+  matchToFunMatch :: Member Report r => S.Match GHC -> Sem r AnyMatch
+  matchToFunMatch (S.Match matchSrcSpan name pats rhs mBinds)          = do
+    let name' = transformName GHC.varName name
+    return
+      $ AnyMatch
+      { anyMatchSrcSpan  = matchSrcSpan
+      , anyMatchContext  = GHC.FunRhs
+          { GHC.mc_fun        = name'
+          , GHC.mc_fixity     = GHC.Prefix
+          , GHC.mc_strictness = GHC.NoSrcStrict
+          }
+      , anyMatchPatterns = pats
+      , anyMatchRhs      = rhs
+      , anyMatchBinds    = mBinds
+      }
+  matchToFunMatch (S.InfixMatch matchSrcSpan pat name pats rhs mBinds) = do
+    let name' = transformName GHC.varName name
+    return
+      $ AnyMatch
+      { anyMatchSrcSpan  = matchSrcSpan
+      , anyMatchContext  = GHC.FunRhs
+          { GHC.mc_fun        = name'
+          , GHC.mc_fixity     = GHC.Infix
+          , GHC.mc_strictness = GHC.NoSrcStrict
+          }
+      , anyMatchPatterns = pat : pats
+      , anyMatchRhs      = rhs
+      , anyMatchBinds    = mBinds
+      }
 transformDecl (S.OtherDecl _ (Decl oDecl)) = return oDecl
 
 -------------------------------------------------------------------------------
@@ -116,52 +149,31 @@ transformMaybeBinds (Just (S.BDecls s decls)) = do
         ++ "retransformation. Only function and signature declarations are "
         ++ "allowed!"
 
--- | Type for the contexts where a match or match group can occur in the GHC
---   AST data structure.
-data MatchContext = Function | LambdaExp | CaseAlt
- deriving ( Eq, Show )
-
--- | Transforms a match context, a GHC source span of the matches and a list of
---   HST matches with into a GHC match group.
-transformMatches :: Member Report r
-                 => MatchContext
-                 -> GHC.SrcSpan
-                 -> [S.Match GHC]
-                 -> Sem r (GHC.MatchGroup GHC.GhcPs (GHC.LHsExpr GHC.GhcPs))
-transformMatches ctxt s matches = do
-  matches' <- mapM (transformMatch ctxt) matches
-  return GHC.MG { GHC.mg_ext    = GHC.NoExtField
-                , GHC.mg_alts   = GHC.L s matches'
-                , GHC.mg_origin = GHC.FromSource
-                }
+-- | Creates a located GHC match group with the given source span that contains
+--   the given matches.
+makeMatchGroup :: GHC.SrcSpan
+               -> [GHC.LMatch GHC.GhcPs (GHC.LHsExpr GHC.GhcPs)]
+               -> GHC.MatchGroup GHC.GhcPs (GHC.LHsExpr GHC.GhcPs)
+makeMatchGroup s matches = GHC.MG
+  { GHC.mg_ext    = GHC.NoExtField
+  , GHC.mg_alts   = GHC.L s matches
+  , GHC.mg_origin = GHC.FromSource
+  }
 
 -- | Transforms an HST match with a match context into a GHC located match.
 transformMatch :: Member Report r
-               => MatchContext
-               -> S.Match GHC
+               => AnyMatch
                -> Sem r (GHC.LMatch GHC.GhcPs (GHC.LHsExpr GHC.GhcPs))
-transformMatch ctxt match = do
-  let (s, name, pats, rhs, mBinds, fixity) = case match of
-        S.Match s' name' pats' rhs' mBinds'          ->
-          (s', name', pats', rhs', mBinds', GHC.Prefix)
-        S.InfixMatch s' pat name' pats' rhs' mBinds' ->
-          (s', name', pat : pats', rhs', mBinds', GHC.Infix)
-      ctxt' = case ctxt of
-        Function  -> GHC.FunRhs
-          { GHC.mc_fun        = transformName GHC.varName name
-          , GHC.mc_fixity     = fixity
-          , GHC.mc_strictness = GHC.NoSrcStrict
-          }
-        LambdaExp -> GHC.LambdaExpr
-        CaseAlt   -> GHC.CaseAlt
+transformMatch (AnyMatch s ctxt pats rhs mBinds) = do
+  let s' = transformSrcSpan s
   pats' <- mapM transformPat pats
-  grhss <- transformRhs rhs mBinds
+  grhss' <- transformRhs rhs mBinds
   return
-    $ GHC.L (transformSrcSpan s) GHC.Match
+    $ GHC.L s' GHC.Match
     { GHC.m_ext   = GHC.NoExtField
-    , GHC.m_ctxt  = ctxt'
+    , GHC.m_ctxt  = ctxt
     , GHC.m_pats  = pats'
-    , GHC.m_grhss = grhss
+    , GHC.m_grhss = grhss'
     }
 
 -- | Transforms an HST right-hand side and binding group into GHC guarded
@@ -232,12 +244,16 @@ transformExp (S.App s e1 e2) = GHC.L (transformSrcSpan s)
   <$> (GHC.HsApp GHC.NoExtField <$> transformExp e1 <*> transformExp e2)
 transformExp (S.NegApp s e) = GHC.L (transformSrcSpan s)
   <$> (GHC.NegApp GHC.NoExtField <$> transformExp e <*> return GHC.noSyntaxExpr)
-transformExp (S.Lambda s pats e)
-  = let s'    = transformSrcSpan s
-        match = S.Match s (S.Ident S.NoSrcSpan "") pats
-          (S.UnGuardedRhs (S.getSrcSpan e) e) Nothing
-    in GHC.L s'
-       <$> (GHC.HsLam GHC.NoExtField <$> transformMatches LambdaExp s' [match])
+transformExp (S.Lambda s pats e) = do
+  let s'    = transformSrcSpan s
+      match = AnyMatch { anyMatchSrcSpan  = s
+                       , anyMatchContext  = GHC.LambdaExpr
+                       , anyMatchPatterns = pats
+                       , anyMatchRhs      = S.UnGuardedRhs (S.getSrcSpan e) e
+                       , anyMatchBinds    = Nothing
+                       }
+  match' <- transformMatch match
+  return $ GHC.L s' (GHC.HsLam GHC.NoExtField (makeMatchGroup s' [match']))
 transformExp (S.Let s binds e) = GHC.L (transformSrcSpan s)
   <$> (GHC.HsLet GHC.NoExtField <$> transformMaybeBinds (Just binds)
        <*> transformExp e)
@@ -267,22 +283,28 @@ transformExp (S.Paren s e) = GHC.L (transformSrcSpan s)
 transformExp (S.ExpTypeSig s e (SigType typ)) = GHC.L (transformSrcSpan s)
   <$> (GHC.ExprWithTySig GHC.NoExtField <$> transformExp e <*> return typ)
 
+-- | Transforms HST @case@-expression alternatives to a GHC match group.
+--
+--   The source span information of the group of case alternatives seems to be
+--   missing in the HSE syntax and therefore in our syntax, so the source span
+--   of the entire case construct (first argumet) is inserted instead.
 transformAlts :: Member Report r
               => GHC.SrcSpan
               -> [S.Alt GHC]
               -> Sem r (GHC.MatchGroup GHC.GhcPs (GHC.LHsExpr GHC.GhcPs))
-
--- The source span information of the group of case alternatives seems to be
--- missing in the HSE syntax and therefore in our syntax, so the source span
--- of the entire case construct is inserted instead
-transformAlts s alts = transformMatches CaseAlt s (map altToMatch alts)
+transformAlts s alts = do
+  let matches = map altToMatch alts
+  matches' <- mapM transformMatch matches
+  return $ makeMatchGroup s matches'
  where
-  -- TODO can we have an helper function for the conversion of matches, @case@
-  -- alternatives and lambdas that takes an optional name such that no empty
-  -- identifier with 'S.NoSrcSpan' has to be created?
-  altToMatch :: S.Alt GHC -> S.Match GHC
-  altToMatch (S.Alt s' pat rhs mBinds) = S.Match s' (S.Ident S.NoSrcSpan "")
-    [pat] rhs mBinds
+  altToMatch :: S.Alt GHC -> AnyMatch
+  altToMatch (S.Alt s' pat rhs mBinds) = AnyMatch
+    { anyMatchSrcSpan  = s'
+    , anyMatchContext  = GHC.CaseAlt
+    , anyMatchPatterns = [pat]
+    , anyMatchRhs      = rhs
+    , anyMatchBinds    = mBinds
+    }
 
 -------------------------------------------------------------------------------
 -- Patterns                                                                  --

--- a/src/lib/HST/Frontend/GHC/To.hs
+++ b/src/lib/HST/Frontend/GHC/To.hs
@@ -287,7 +287,7 @@ transformExp (S.ExpTypeSig s e (SigType typ)) = GHC.L (transformSrcSpan s)
 --
 --   The source span information of the group of case alternatives seems to be
 --   missing in the HSE syntax and therefore in our syntax, so the source span
---   of the entire case construct (first argumet) is inserted instead.
+--   of the entire case construct (first argument) is inserted instead.
 transformAlts :: Member Report r
               => GHC.SrcSpan
               -> [S.Alt GHC]

--- a/src/lib/HST/Frontend/GHC/To.hs
+++ b/src/lib/HST/Frontend/GHC/To.hs
@@ -277,6 +277,9 @@ transformAlts :: Member Report r
 -- of the entire case construct is inserted instead
 transformAlts s alts = transformMatches CaseAlt s (map altToMatch alts)
  where
+  -- TODO can we have an helper function for the conversion of matches, @case@
+  -- alternatives and lambdas that takes an optional name such that no empty
+  -- identifier with 'S.NoSrcSpan' has to be created?
   altToMatch :: S.Alt GHC -> S.Match GHC
   altToMatch (S.Alt s' pat rhs mBinds) = S.Match s' (S.Ident S.NoSrcSpan "")
     [pat] rhs mBinds

--- a/src/lib/HST/Frontend/GHC/Util/AnyMatch.hs
+++ b/src/lib/HST/Frontend/GHC/Util/AnyMatch.hs
@@ -16,12 +16,12 @@ data AnyMatch = AnyMatch
     -- ^ The source span of the match.
   , anyMatchContext
       :: GHC.HsMatchContext (GHC.NameOrRdrName (GHC.IdP GHC.GhcPs))
-    -- ^ Additional information about the match that has not been transfomed
+    -- ^ Additional information about the match that has not been transformed
     --   yet.
   , anyMatchPatterns :: [S.Pat GHC]
     -- ^ The patterns that are matched by this match.
   , anyMatchRhs      :: S.Rhs GHC
     -- ^ The right-hand side of the match.
   , anyMatchBinds    :: Maybe (S.Binds GHC)
-    -- ^ Bindings of an options `where`-clause of the match.
+    -- ^ Bindings of an optional @where@-clause of the match.
   }

--- a/src/lib/HST/Frontend/GHC/Util/AnyMatch.hs
+++ b/src/lib/HST/Frontend/GHC/Util/AnyMatch.hs
@@ -2,7 +2,7 @@
 --   function declarations, lambda abstractions and @case@ alternatives from
 --   and to the @ghc-lib-parser@ AST.
 --
---   In the GHC AST, the nodes for matches is used not just for function
+--   In the GHC AST, the nodes for matches are used not just for function
 --   declarations but also for lambda abstractions and @case@ alternatives.
 --   Additional information such as the name of the matched function is stored
 --   in a 'GHC.HsMatchContext'. The remaining information is the same in every

--- a/src/lib/HST/Frontend/GHC/Util/AnyMatch.hs
+++ b/src/lib/HST/Frontend/GHC/Util/AnyMatch.hs
@@ -1,8 +1,15 @@
--- | This module contains a data type that is used for the transformation from
+-- | This module contains a data type that is used for the transformation of
+--   function declarations, lambda abstractions and @case@ alternatives from
 --   and to the @ghc-lib-parser@ AST.
 --
---   In GHC-lib, the AST node for match groups is
-module HST.Frontend.GHC.Util.AnyMatch where
+--   In the GHC AST, the nodes for matches is used not just for function
+--   declarations but also for lambda abstractions and @case@ alternatives.
+--   Additional information such as the name of the matched function is stored
+--   in a 'GHC.HsMatchContext'. The remaining information is the same in every
+--   case. In order to avoid code duplication, the AST transformation uses
+--   the data type defined in this module to transform the parts of a match
+--   that are not context specific.
+module HST.Frontend.GHC.Util.AnyMatch (AnyMatch(..)) where
 
 import qualified GHC.Hs                  as GHC
 

--- a/src/lib/HST/Frontend/GHC/Util/AnyMatch.hs
+++ b/src/lib/HST/Frontend/GHC/Util/AnyMatch.hs
@@ -2,20 +2,20 @@
 --   and to the @ghc-lib-parser@ AST.
 --
 --   In GHC-lib, the AST node for match groups is
-
 module HST.Frontend.GHC.Util.AnyMatch where
 
-import qualified GHC.Hs                            as GHC
+import qualified GHC.Hs                  as GHC
 
-import qualified HST.Frontend.Syntax as S
-import  HST.Frontend.GHC.Config
+import           HST.Frontend.GHC.Config
+import qualified HST.Frontend.Syntax     as S
 
 -- | A data type that is used for the transformation of all nodes with pattern
 --   matching, i.e., 'S.Match'es, 'S.Lambda' abstractions and 'S.Alt'ernatives.
 data AnyMatch = AnyMatch
   { anyMatchSrcSpan  :: S.SrcSpan GHC
     -- ^ The source span of the match.
-  , anyMatchContext  :: GHC.HsMatchContext (GHC.NameOrRdrName (GHC.IdP GHC.GhcPs))
+  , anyMatchContext
+      :: GHC.HsMatchContext (GHC.NameOrRdrName (GHC.IdP GHC.GhcPs))
     -- ^ Additional information about the match that has not been transfomed
     --   yet.
   , anyMatchPatterns :: [S.Pat GHC]

--- a/src/lib/HST/Frontend/GHC/Util/AnyMatch.hs
+++ b/src/lib/HST/Frontend/GHC/Util/AnyMatch.hs
@@ -9,11 +9,11 @@
 --   case. In order to avoid code duplication, the AST transformation uses
 --   the data type defined in this module to transform the parts of a match
 --   that are not context specific.
-module HST.Frontend.GHC.Util.AnyMatch (AnyMatch(..)) where
+module HST.Frontend.GHC.Util.AnyMatch ( AnyMatch(..) ) where
 
 import qualified GHC.Hs                  as GHC
 
-import           HST.Frontend.GHC.Config
+import           HST.Frontend.GHC.Config ( GHC )
 import qualified HST.Frontend.Syntax     as S
 
 -- | A data type that is used for the transformation of all nodes with pattern

--- a/src/lib/HST/Frontend/GHC/Util/AnyMatch.hs
+++ b/src/lib/HST/Frontend/GHC/Util/AnyMatch.hs
@@ -1,0 +1,27 @@
+-- | This module contains a data type that is used for the transformation from
+--   and to the @ghc-lib-parser@ AST.
+--
+--   In GHC-lib, the AST node for match groups is
+
+module HST.Frontend.GHC.Util.AnyMatch where
+
+import qualified GHC.Hs                            as GHC
+
+import qualified HST.Frontend.Syntax as S
+import  HST.Frontend.GHC.Config
+
+-- | A data type that is used for the transformation of all nodes with pattern
+--   matching, i.e., 'S.Match'es, 'S.Lambda' abstractions and 'S.Alt'ernatives.
+data AnyMatch = AnyMatch
+  { anyMatchSrcSpan  :: S.SrcSpan GHC
+    -- ^ The source span of the match.
+  , anyMatchContext  :: GHC.HsMatchContext (GHC.NameOrRdrName (GHC.IdP GHC.GhcPs))
+    -- ^ Additional information about the match that has not been transfomed
+    --   yet.
+  , anyMatchPatterns :: [S.Pat GHC]
+    -- ^ The patterns that are matched by this match.
+  , anyMatchRhs      :: S.Rhs GHC
+    -- ^ The right-hand side of the match.
+  , anyMatchBinds    :: Maybe (S.Binds GHC)
+    -- ^ Bindings of an options `where`-clause of the match.
+  }

--- a/src/lib/HST/Frontend/HSE/From.hs
+++ b/src/lib/HST/Frontend/HSE/From.hs
@@ -203,17 +203,16 @@ transformBinds (HSE.IPBinds _ _)    = notSupported "Implicit-parameters"
 -- | Transforms an HSE match into an HST match.
 transformMatch
   :: Member Report r => HSE.Match HSE.SrcSpanInfo -> Sem r (S.Match HSE)
-transformMatch (HSE.Match s name pats rhs mBinds)
-  = S.Match (transformSrcSpan s) <$> transformName name
-  <*> mapM transformPat pats
-  <*> transformRhs rhs
-  <*> mapM transformBinds mBinds
-transformMatch (HSE.InfixMatch s pat name pats rhs mBinds)
-  = S.InfixMatch (transformSrcSpan s) <$> transformPat pat
-  <*> transformName name
-  <*> mapM transformPat pats
-  <*> transformRhs rhs
-  <*> mapM transformBinds mBinds
+transformMatch (HSE.Match s name pats rhs mBinds)          = do
+  S.Match (transformSrcSpan s) False <$> transformName name
+    <*> mapM transformPat pats
+    <*> transformRhs rhs
+    <*> mapM transformBinds mBinds
+transformMatch (HSE.InfixMatch s pat name pats rhs mBinds) = do
+  S.Match (transformSrcSpan s) True <$> transformName name
+    <*> mapM transformPat (pat : pats)
+    <*> transformRhs rhs
+    <*> mapM transformBinds mBinds
 
 -- | Transforms an HSE right hand side into an HST right hand side.
 transformRhs :: Member Report r => HSE.Rhs HSE.SrcSpanInfo -> Sem r (S.Rhs HSE)

--- a/src/lib/HST/Frontend/HSE/From.hs
+++ b/src/lib/HST/Frontend/HSE/From.hs
@@ -203,16 +203,16 @@ transformBinds (HSE.IPBinds _ _)    = notSupported "Implicit-parameters"
 -- | Transforms an HSE match into an HST match.
 transformMatch
   :: Member Report r => HSE.Match HSE.SrcSpanInfo -> Sem r (S.Match HSE)
-transformMatch (HSE.Match s name pats rhs mBinds)          = do
-  S.Match (transformSrcSpan s) False <$> transformName name
-    <*> mapM transformPat pats
-    <*> transformRhs rhs
-    <*> mapM transformBinds mBinds
-transformMatch (HSE.InfixMatch s pat name pats rhs mBinds) = do
-  S.Match (transformSrcSpan s) True <$> transformName name
-    <*> mapM transformPat (pat : pats)
-    <*> transformRhs rhs
-    <*> mapM transformBinds mBinds
+transformMatch (HSE.Match s name pats rhs mBinds)
+  = S.Match (transformSrcSpan s) False <$> transformName name
+  <*> mapM transformPat pats
+  <*> transformRhs rhs
+  <*> mapM transformBinds mBinds
+transformMatch (HSE.InfixMatch s pat name pats rhs mBinds)
+  = S.Match (transformSrcSpan s) True <$> transformName name
+  <*> mapM transformPat (pat : pats)
+  <*> transformRhs rhs
+  <*> mapM transformBinds mBinds
 
 -- | Transforms an HSE right hand side into an HST right hand side.
 transformRhs :: Member Report r => HSE.Rhs HSE.SrcSpanInfo -> Sem r (S.Rhs HSE)

--- a/src/lib/HST/Frontend/HSE/To.hs
+++ b/src/lib/HST/Frontend/HSE/To.hs
@@ -55,12 +55,12 @@ transformBinds (S.BDecls s decls) = HSE.BDecls (transformSrcSpan s)
 
 -- | Transforms an HST match into an HSE match.
 transformMatch :: S.Match HSE -> HSE.Match HSE.SrcSpanInfo
-transformMatch (S.Match s name pats rhs mBinds)          = HSE.Match
-  (transformSrcSpan s) (transformName name) (map transformPat pats)
-  (transformRhs rhs) (fmap transformBinds mBinds)
-transformMatch (S.InfixMatch s pat name pats rhs mBinds) = HSE.InfixMatch
-  (transformSrcSpan s) (transformPat pat) (transformName name)
-  (map transformPat pats) (transformRhs rhs) (fmap transformBinds mBinds)
+transformMatch (S.Match s isInfix name pats rhs mBinds)
+  | not isInfix = HSE.Match (transformSrcSpan s) (transformName name)
+    (map transformPat pats) (transformRhs rhs) (fmap transformBinds mBinds)
+  | otherwise = HSE.InfixMatch (transformSrcSpan s) (transformPat (head pats))
+    (transformName name) (map transformPat (tail pats)) (transformRhs rhs)
+    (fmap transformBinds mBinds)
 
 -- | Transforms an HST right hand side into an HSE right hand side.
 transformRhs :: S.Rhs HSE -> HSE.Rhs HSE.SrcSpanInfo

--- a/src/lib/HST/Frontend/Syntax.hs
+++ b/src/lib/HST/Frontend/Syntax.hs
@@ -147,9 +147,14 @@ instance HasSrcSpan Binds where
   getSrcSpan (BDecls srcSpan _) = srcSpan
 
 -- | A match belonging to a function binding declaration.
-data Match a
-  = Match (SrcSpan a) (Name a) [Pat a] (Rhs a) (Maybe (Binds a))
-  | InfixMatch (SrcSpan a) (Pat a) (Name a) [Pat a] (Rhs a) (Maybe (Binds a))
+data Match a = Match
+  { matchSrcSpan :: SrcSpan a
+  , matchIsInfix :: Bool
+  , matchName    :: Name a
+  , matchPats    :: [Pat a]
+  , matchRhs     :: Rhs a
+  , matchBinds   :: Maybe (Binds a)
+  }
 
 deriving instance EqAST a => Eq (Match a)
 
@@ -157,8 +162,7 @@ deriving instance ShowAST a => Show (Match a)
 
 -- | Gets the source span information of a match of a function declaration.
 instance HasSrcSpan Match where
-  getSrcSpan (Match srcSpan _ _ _ _)        = srcSpan
-  getSrcSpan (InfixMatch srcSpan _ _ _ _ _) = srcSpan
+  getSrcSpan = matchSrcSpan
 
 -- | A right hand side belonging to a 'Match'.
 data Rhs a

--- a/src/lib/HST/Frontend/Syntax.hs
+++ b/src/lib/HST/Frontend/Syntax.hs
@@ -427,7 +427,7 @@ class HasSrcSpan node where
 
 -- | A wrapper for source span information with the option to not specify a
 --   source span.
-data SrcSpan a = SrcSpan (SrcSpanType a) | NoSrcSpan
+data SrcSpan a = SrcSpan { originalSrcSpan :: SrcSpanType a } | NoSrcSpan
 
 deriving instance ShowAST a => Show (SrcSpan a)
 


### PR DESCRIPTION
<!--
  Have you read our Code of Conduct?
  By filing an issue or pull request, you are expected to comply with it, including treating everyone with respect:
  https://github.com/FreeProving/guidelines/blob/main/CODE_OF_CONDUCT.md
-->

### Issue

<!--
  Link to the issue that this pull request addresses.
  If there is not yet a corresponding issue, please open a new issue and then link to that issue in your pull request.
  Give any additional information that is not covered by the linked issue but might be important for the reviewer.
-->
Linter rules for #34.

### Description of the Change

<!--
  Give a short summary of the changes you made to handle the issue.
  Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.
-->
The usage of `NoSrcSpan` was restricted in the HLint configuration file. To use `NoSrcSpan` an exception has to be added to `.hlint.yaml` per module. Exceptions have been added for all current usages of `NoSrcSpan`. A comment was added to every exception that justifies the usage of `NoSrcSpan`. Some additional usages of `NoSrcSpan` that were easy to avoid have been removed.