### PR TITLE
Prevent infinite loop in core algorithm

### DIFF
--- a/src/lib/HST/CoreAlgorithm.hs
+++ b/src/lib/HST/CoreAlgorithm.hs
@@ -80,9 +80,17 @@ match vars@(x : xs) eqs er
     -- Rule 4: Pattern lists of some equations start with a variable pattern
     -- and others start with a constructor pattern.
     --
-    -- TODO This is probably causing the infinite loops when there are
-    --      unsupported patterns.
-    otherwise = createRekMatch vars er (groupByFirstPatType eqs)
+    -- If all patterns are in the same group (i.e., there is only one group),
+    -- the recursive call to 'match' in 'createRekMatch' would cause an
+    -- infinite loop. An internal error is reported in this case to ensure
+    -- termination.
+    otherwise = let groups = groupByFirstPatType eqs
+                in if length groups == 1
+                     then reportFatal
+                       $ Message Internal
+                       $ "Failed to group equations by pattern type. "
+                       ++ "All patterns are in the same group."
+                     else createRekMatch vars er groups
 match [] _ _               = reportFatal
   $ Message Error
   $ "Equations have different number of arguments."


### PR DESCRIPTION
<!--
  Have you read our Code of Conduct?
  By filing an issue or pull request, you are expected to comply with it, including treating everyone with respect:
  https://github.com/FreeProving/guidelines/blob/main/CODE_OF_CONDUCT.md
-->

### Issue

<!--
  Link to the issue that this pull request addresses.
  If there is not yet a corresponding issue, please open a new issue and then link to that issue in your pull request.
  Give any additional information that is not covered by the linked issue but might be important for the reviewer.
-->
Closes #13.

### Description of the Change

<!--
  Give a short summary of the changes you made to handle the issue.
  Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.
-->
Issue #13 was caused (prior to the implementation of our own AST) by the `match` function of the core algorithm. If there was an unsupported pattern (that is neither classified as a constructor nor variable pattern), not all patterns are variable patterns and not all patterns are constructor patterns. Thus, rule 4 is applied and the core algorithm groups the pattern list by pattern type. One of the resulting groups contains the unsupported pattern. Therefore, rule 4 needs to be applied again in the the recursive call for this group which causes an infinite loop. This fix prevents the infinite loop by detecting whether the equation list was split into more than one group. If it is, the algorithm has to terminate eventually. Otherwise, an internal error is reported.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->
We could also change the guard of rule 4 to test whether there are both variable and constructor patterns and report the error in a separate catch-all clause.
### Verification Process

<!--
  What process did you follow to verify that your change has the desired effects and has not introduced any regressions?
  Describe the actions you performed (including input you checked, tests you created, commands you ran, etc.), and describe the results you observed.
-->
I've tested the implementation by adding as-patterns to the HSE front end locally and running the example from the issue. I've implemented `isVarPat` and `isConPat` such that `False` is returned in both cases. When the fix was disabled, the algorithm did not terminate. I could not observe any memory issues this time but I'm not sure why (i.e., we may have accidentally fixed a memory leak in the meantime). When the fix was enabled, the program terminated with the expected error message.

