### PR TITLE
Add Support for Qualified Identifiers

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -53,25 +53,25 @@
       # `NoSrcSpan` such that users of the effect are forced to discard
       # location information explicitly.
     - HST.Effect.Fresh
-    # During the transformation, given source spans have to be converted to
-    # HST syntax
+      # During the transformation, given source spans have to be converted to
+      # HST syntax.
     - HST.Frontend.HSE.From
     - HST.Frontend.GHC.From
-    # During the back-transformation, missing source spans have to be converted
-    # to the original AST data type.
+      # During the back-transformation, missing source spans have to be converted
+      # to the original AST data type.
     - HST.Frontend.GHC.To
     - HST.Frontend.HSE.To
       # Messages when asking for options do not have a source span so they have
-      # to be annotated with no souce span.
+      # to be annotated with no source span.
     - HST.Options
-    # In tests, it is necessary to use `NoSrcSpan`.
+      # In tests, it is necessary to use `NoSrcSpan`.
     - HST.ApplicationTests
     - HST.CoreAlgorithmTests
-    - HST.EnvironmentTests
     - HST.Effect.CancelTests
     - HST.Effect.FreshTests
     - HST.Effect.ReportTests
     - HST.Effect.SetExpectation
+    - HST.EnvironmentTests
     - HST.Test.Expectation
     - HST.Test.Parser
     - HST.Test.Runner
@@ -81,9 +81,9 @@
 
 # Aliases for qualified imports.
 - modules:
+  - {name: [ Data.Map.Strict ], as: Map}
   - {name: [ Data.Set ], as: Set}
   - {name: [ Data.Set.Ordered ], as: OSet}
-  - {name: [ Data.Map.Strict ], as: Map}
   - {name: [ HST.Frontend.GHC.From ], as: FromGHC}
   - {name: [ HST.Frontend.GHC.To ], as: ToGHC}
   - {name: [ HST.Frontend.HSE.From ], as: FromHSE}

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -27,9 +27,9 @@
     within:
       # In main, we have errors that have no source span.
     - Main
-      # Messages when asking for options do not have a source span so they have
-      # to be annotated with no souce span.
-    - HST.Options
+      # There are reported messages without source spans in the `Application`
+      # module.
+    - HST.Application
       # Many artificial nodes are generated in the core algorithm and during
       # guard elimination. There is not a good source span for all of them.
     - HST.CoreAlgorithm
@@ -61,6 +61,9 @@
     # to the original AST data type.
     - HST.Frontend.GHC.To
     - HST.Frontend.HSE.To
+      # Messages when asking for options do not have a source span so they have
+      # to be annotated with no souce span.
+    - HST.Options
     # In tests, it is necessary to use `NoSrcSpan`.
     - HST.ApplicationTests
     - HST.CoreAlgorithmTests

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -67,6 +67,7 @@
     # In tests, it is necessary to use `NoSrcSpan`.
     - HST.ApplicationTests
     - HST.CoreAlgorithmTests
+    - HST.EnvironmentTests
     - HST.Effect.CancelTests
     - HST.Effect.FreshTests
     - HST.Effect.ReportTests

--- a/haskell-src-transformations.cabal
+++ b/haskell-src-transformations.cabal
@@ -145,6 +145,7 @@ test-suite haskell-src-transformations-unit-tests
                     , HST.Effect.FreshTests
                     , HST.Effect.ReportTests
                     , HST.Effect.SetExpectation
+                    , HST.EnvironmentTests
                     , HST.Test.Expectation
                     , HST.Test.Parser
                     , HST.Test.Runner

--- a/src/lib/HST/Application.hs
+++ b/src/lib/HST/Application.hs
@@ -32,7 +32,8 @@ import           HST.Feature.GuardElimination ( applyGEModule )
 import           HST.Feature.Optimization     ( optimize )
 import qualified HST.Frontend.Syntax          as S
 import           HST.Options                  ( optOptimizeCase )
-import           HST.Util.Messages            ( Severity(Internal, Warning), message )
+import           HST.Util.Messages
+  ( Severity(Internal, Warning), message )
 import           HST.Util.Predicates          ( isConPat )
 import           HST.Util.PrettyName          ( prettyName )
 import           HST.Util.Selectors           ( expFromUnguardedRhs )
@@ -160,8 +161,8 @@ initializeEnvironment filePath = do
   currentModule <- getInputModuleInterface filePath
   mInterfaces <- mapM (getInputModuleInterfaceByName . S.importModule) imports
   mImportedModules <- zipWithM reportMissingModule imports mInterfaces
-  importedModules <- mapM collectImportDecls $
-    groupSortOn (interfaceModName . snd) (catMaybes mImportedModules)
+  importedModules <- mapM collectImportDecls
+    $ groupSortOn (interfaceModName . snd) (catMaybes mImportedModules)
   return Environment { envCurrentModule   = currentModule
                      , envImportedModules = importedModules
                      , envOtherEntries    = preludeModuleInterface
@@ -194,8 +195,8 @@ initializeEnvironment filePath = do
   collectImportDecls :: Member Report r
                      => [(S.ImportDecl a, ModuleInterface a)]
                      -> Sem r ([S.ImportDecl a], ModuleInterface a)
-  collectImportDecls imports@((_, interface) : _) =
-    return (map fst imports, interface)
-  collectImportDecls [] =
-    reportFatal $ message Internal S.NoSrcSpan $
-      "`collectImportDecls` was called on an empty list!"
+  collectImportDecls imports@((_, interface) : _)
+    = return (map fst imports, interface)
+  collectImportDecls [] = reportFatal
+    $ message Internal S.NoSrcSpan
+    $ "`collectImportDecls` was called on an empty list!"

--- a/src/lib/HST/Application.hs
+++ b/src/lib/HST/Application.hs
@@ -10,6 +10,7 @@ module HST.Application
 -- TODO only tuples supported
 import           Control.Monad                ( zipWithM )
 import           Control.Monad.Extra          ( ifM )
+import           Data.List.Extra              ( groupSortOn )
 import qualified Data.Map.Strict              as Map
 import           Data.Maybe                   ( catMaybes, mapMaybe )
 import           Polysemy                     ( Member, Members, Sem )
@@ -23,7 +24,7 @@ import           HST.Effect.InputModule
   ( ConEntry(..), DataEntry(..), InputModule, ModuleInterface(..)
   , createConMapEntries, createDataMapEntry, getInputModule
   , getInputModuleInterface, getInputModuleInterfaceByName )
-import           HST.Effect.Report            ( Report, report )
+import           HST.Effect.Report            ( Report, report, reportFatal )
 import           HST.Environment              ( Environment(..) )
 import           HST.Environment.Prelude      ( preludeModuleInterface )
 import           HST.Feature.CaseCompletion   ( applyCCModule )
@@ -31,7 +32,7 @@ import           HST.Feature.GuardElimination ( applyGEModule )
 import           HST.Feature.Optimization     ( optimize )
 import qualified HST.Frontend.Syntax          as S
 import           HST.Options                  ( optOptimizeCase )
-import           HST.Util.Messages            ( Severity(Warning), message )
+import           HST.Util.Messages            ( Severity(Internal, Warning), message )
 import           HST.Util.Predicates          ( isConPat )
 import           HST.Util.PrettyName          ( prettyName )
 import           HST.Util.Selectors           ( expFromUnguardedRhs )
@@ -159,8 +160,10 @@ initializeEnvironment filePath = do
   currentModule <- getInputModuleInterface filePath
   mInterfaces <- mapM (getInputModuleInterfaceByName . S.importModule) imports
   mImportedModules <- zipWithM reportMissingModule imports mInterfaces
+  importedModules <- mapM collectImportDecls $
+    groupSortOn (interfaceModName . snd) (catMaybes mImportedModules)
   return Environment { envCurrentModule   = currentModule
-                     , envImportedModules = catMaybes mImportedModules
+                     , envImportedModules = importedModules
                      , envOtherEntries    = preludeModuleInterface
                      }
  where
@@ -180,3 +183,19 @@ initializeEnvironment filePath = do
     return Nothing
   reportMissingModule importDecl (Just moduleInterface)
     = return $ Just (importDecl, moduleInterface)
+
+  -- | Collects all import declarations in the given list of pairs of import
+  --   declarations and module interfaces and returns a single pair with these
+  --   import declarations and the module interface of the first entry of the
+  --   given list.
+  --
+  --   This function is meant to collect multiple import declarations referring
+  --   to the same module.
+  collectImportDecls :: Member Report r
+                     => [(S.ImportDecl a, ModuleInterface a)]
+                     -> Sem r ([S.ImportDecl a], ModuleInterface a)
+  collectImportDecls imports@((_, interface) : _) =
+    return (map fst imports, interface)
+  collectImportDecls [] =
+    reportFatal $ message Internal S.NoSrcSpan $
+      "`collectImportDecls` was called on an empty list!"

--- a/src/lib/HST/CoreAlgorithm.hs
+++ b/src/lib/HST/CoreAlgorithm.hs
@@ -171,7 +171,9 @@ identifyMissingCons []   = reportFatal
 identifyMissingCons alts = do
   matchedConNames <- mapM getAltConName alts
   conEntries <- findConEntries (head matchedConNames)
-  return $ filter (not . flip any matchedConNames . S.eqUnQual . conEntryName) conEntries
+  return
+    $ filter (not . flip any matchedConNames . S.eqUnQual . conEntryName)
+    conEntries
 
 -- | Looks up the data constructor entries of the data type that the given data
 --   constructor name belongs to in the current environment.

--- a/src/lib/HST/CoreAlgorithm.hs
+++ b/src/lib/HST/CoreAlgorithm.hs
@@ -171,7 +171,7 @@ identifyMissingCons []   = reportFatal
 identifyMissingCons alts = do
   matchedConNames <- mapM getAltConName alts
   conEntries <- findConEntries (head matchedConNames)
-  return $ filter (flip all matchedConNames . (/=) . conEntryName) conEntries
+  return $ filter (not . flip any matchedConNames . S.eqUnQual . conEntryName) conEntries
 
 -- | Looks up the data constructor entries of the data type that the given data
 --   constructor name belongs to in the current environment.

--- a/src/lib/HST/Environment.hs
+++ b/src/lib/HST/Environment.hs
@@ -11,6 +11,7 @@ module HST.Environment
   , lookupTypeName
   ) where
 
+import           Data.Bifunctor         ( first )
 import           Data.Map.Strict        ( Map )
 import qualified Data.Map.Strict        as Map
 import           Data.Maybe             ( fromMaybe, mapMaybe )
@@ -54,7 +55,7 @@ lookupConEntries :: TypeName a
                  -> Environment a
                  -> [(Maybe (S.ModuleName a), Maybe [ConEntry a])]
 lookupConEntries typeName env = map
-  (qualifyLookupResult (\x -> sequence . map (qualifyConEntry env x)))
+  (qualifyLookupResult (\x -> mapM (qualifyConEntry env x)))
   (lookupWith interfaceDataCons typeName env)
 
 -- | Looks up the data type names belonging to the the given data constructor
@@ -100,7 +101,7 @@ possibleInterfaces :: S.QName a
                    -> [(Maybe (S.ImportDecl a), ModuleInterface a)]
 possibleInterfaces qName env = filter (fitsToInterface qName . snd)
   [(Nothing, envCurrentModule env), (Nothing, envOtherEntries env)]
-  ++ map (\(x, y) -> (Just x, y))
+  ++ map (first Just)
   (filter (fitsToImport qName . fst) (envImportedModules env))
  where
   -- | Checks if the given possibly qualified name could refer to an entry of

--- a/src/lib/HST/Environment.hs
+++ b/src/lib/HST/Environment.hs
@@ -89,16 +89,8 @@ lookupWith :: (ModuleInterface a -> Map (S.QName a) v)
            -> Environment a
            -> [((Maybe (S.ImportDecl a), ModuleInterface a), v)]
 lookupWith getMap qName env = mapMaybe
-  (\x -> fmap (x, ) (Map.lookup (unQualifyName qName) (getMap (snd x))))
+  (\x -> fmap (x, ) (Map.lookup (S.unQualifyQName qName) (getMap (snd x))))
   (possibleInterfaces qName env)
- where
-  -- | Removes the possible qualification of the given 'S.QName'.
-  --
-  --   Other 'S.QName's, including special names for built-in data
-  --   constructors, are returned as given.
-  unQualifyName :: S.QName a -> S.QName a
-  unQualifyName (S.Qual s _ name) = S.UnQual s name
-  unQualifyName uqName            = uqName
 
 -- | Returns the list of all module interfaces in the given environment with
 --   their import declarations, where available, that the given possibly

--- a/src/lib/HST/Environment.hs
+++ b/src/lib/HST/Environment.hs
@@ -11,16 +11,16 @@ module HST.Environment
   , lookupTypeName
   ) where
 
-import           Data.Bifunctor         ( first, second )
+import           Data.Bifunctor            ( first, second )
 import           Data.Containers.ListUtils ( nubOrdOn )
-import           Data.List              ( find )
-import           Data.Map.Strict        ( Map )
-import qualified Data.Map.Strict        as Map
-import           Data.Maybe             ( fromMaybe, mapMaybe, maybeToList )
+import           Data.List                 ( find )
+import           Data.Map.Strict           ( Map )
+import qualified Data.Map.Strict           as Map
+import           Data.Maybe                ( fromMaybe, mapMaybe, maybeToList )
 
 import           HST.Effect.InputModule
   ( ConEntry(..), ConName, DataEntry(..), ModuleInterface(..), TypeName )
-import qualified HST.Frontend.Syntax    as S
+import qualified HST.Frontend.Syntax       as S
 
 -------------------------------------------------------------------------------
 -- Environment                                                               --
@@ -182,13 +182,13 @@ qualifyQNameEnv :: (ModuleInterface a -> Map (S.QName a) v)
                 -> Maybe (Bool, S.ModuleName a)
                 -> S.QName a
                 -> Maybe (S.QName a)
-qualifyQNameEnv getMap env qualInfo uqName =
-  let mustBeQual          = maybe False fst qualInfo
-      modNames            = maybeToList (snd <$> qualInfo)
-      qNames              = [uqName | not mustBeQual]
-        ++ (qualifyQName uqName <$> modNames)
-      isUnambigious qName = length (lookupWith getMap qName env) == 1
-  in find isUnambigious qNames
+qualifyQNameEnv getMap env qualInfo uqName
+  = let mustBeQual          = maybe False fst qualInfo
+        modNames            = maybeToList (snd <$> qualInfo)
+        qNames              = [uqName | not mustBeQual]
+          ++ (qualifyQName uqName <$> modNames)
+        isUnambigious qName = length (lookupWith getMap qName env) == 1
+    in find isUnambigious qNames
  where
   -- | Qualifies the given unqualified 'S.QName' by the given module name.
   --

--- a/src/lib/HST/Environment.hs
+++ b/src/lib/HST/Environment.hs
@@ -32,7 +32,10 @@ data Environment a = Environment
     --   and data constructors.
   , envImportedModules :: [([S.ImportDecl a], ModuleInterface a)]
     -- ^ A list of all successfully imported module interfaces including their
-    --   import declarations. 
+    --   lists of import declarations.
+    --
+    --   A list of import declarations instead of a single one is stored
+    --   because multiple import declarations could refer to the same module.
   , envOtherEntries    :: ModuleInterface a
     -- ^ A module interface containing all other data types and data
     --   constructors currently in scope.

--- a/src/lib/HST/Environment.hs
+++ b/src/lib/HST/Environment.hs
@@ -81,10 +81,9 @@ lookupTypeName conName env = map
 -------------------------------------------------------------------------------
 -- | Looks up the given data type or constructor name in the maps gotten when
 --   applying the given function to the module interfaces in the given
---   environment. In addition to the lists of data constructor entries or data
---   type names found, the result includes the import declarations, where
---   available, and the module interfaces of the modules the found values came
---   from.
+--   environment. In addition to the data type entries or constructor entries
+--   found, the result includes the import declarations, where available, and
+--   the module interfaces of the modules the found values came from.
 lookupWith :: (ModuleInterface a -> Map (S.QName a) v)
            -> S.QName a
            -> Environment a

--- a/src/lib/HST/Environment.hs
+++ b/src/lib/HST/Environment.hs
@@ -72,17 +72,14 @@ lookupWith :: (ModuleInterface a -> Map (S.QName a) v)
            -> Environment a
            -> [(Maybe (S.ModuleName a), v)]
 lookupWith getMap qName env = mapMaybe
-  (\i ->
-    fmap (interfaceModName i, ) (Map.lookup (unQualifyName qName) (getMap i)))
-  (possibleInterfaces qName env)
+  (\i -> fmap (interfaceModName i, )
+   (Map.lookup (unQualifyName qName) (getMap i))) (possibleInterfaces qName env)
 
 -- | Returns the list of all module interfaces in the given environment the
 --   given possibly qualified name could refer to.
 possibleInterfaces :: S.QName a -> Environment a -> [ModuleInterface a]
-possibleInterfaces qName env =
-     filter
-       (fitsToInterface qName)
-       [envCurrentModule env, envOtherEntries env]
+possibleInterfaces qName env = filter (fitsToInterface qName)
+  [envCurrentModule env, envOtherEntries env]
   ++ map snd (filter (fitsToImport qName . fst) (envImportedModules env))
 
 -- | Checks if the given possibly qualified name could refer to an entry of the
@@ -94,14 +91,14 @@ possibleInterfaces qName env =
 --   interface name and all unqualified names.
 fitsToInterface :: S.QName a -> ModuleInterface a -> Bool
 fitsToInterface (S.Qual _ modName _) = elem modName . interfaceModName
-fitsToInterface _ = const True
+fitsToInterface _                    = const True
 
 -- | Checks if the given possibly qualified name could refer to an entry of a
 --   module imported with the given import declaration.
 fitsToImport :: S.QName a -> S.ImportDecl a -> Bool
-fitsToImport (S.Qual _ modName _) importDecl = modName ==
-  fromMaybe (S.importModule importDecl) (S.importAsName importDecl)
-fitsToImport _ importDecl = not (S.importIsQual importDecl)
+fitsToImport (S.Qual _ modName _) importDecl = modName
+  == fromMaybe (S.importModule importDecl) (S.importAsName importDecl)
+fitsToImport _ importDecl                    = not (S.importIsQual importDecl)
 
 -- | Removes the possible qualification of the given 'S.QName'.
 --
@@ -109,4 +106,4 @@ fitsToImport _ importDecl = not (S.importIsQual importDecl)
 --   are returned as given.
 unQualifyName :: S.QName a -> S.QName a
 unQualifyName (S.Qual s _ name) = S.UnQual s name
-unQualifyName uqName = uqName
+unQualifyName uqName            = uqName

--- a/src/lib/HST/Environment.hs
+++ b/src/lib/HST/Environment.hs
@@ -11,7 +11,7 @@ module HST.Environment
   , lookupTypeName
   ) where
 
-import           Data.Bifunctor         ( first )
+import           Data.Bifunctor         ( first, second )
 import           Data.Map.Strict        ( Map )
 import qualified Data.Map.Strict        as Map
 import           Data.Maybe             ( fromMaybe, mapMaybe )
@@ -55,8 +55,8 @@ lookupConEntries :: TypeName a
                  -> Environment a
                  -> [(Maybe (S.ModuleName a), Maybe [ConEntry a])]
 lookupConEntries typeName env = map
-  (qualifyLookupResult (mapM . qualifyConEntry env))
-  (lookupWith interfaceDataCons typeName env)
+  (qualifyLookupResult (mapM . qualifyConEntry env) . second dataEntryCons)
+  (lookupWith interfaceDataEntries typeName env)
 
 -- | Looks up the data type names belonging to the the given data constructor
 --   name in the given environment and qualifies them so that they are
@@ -73,8 +73,8 @@ lookupTypeName :: ConName a
                -> Environment a
                -> [(Maybe (S.ModuleName a), Maybe (TypeName a))]
 lookupTypeName conName env = map
-  (qualifyLookupResult (qualifyQNameEnv interfaceDataCons env))
-  (lookupWith interfaceTypeNames conName env)
+  (qualifyLookupResult (qualifyQNameEnv interfaceDataEntries env) . second conEntryType)
+  (lookupWith interfaceConEntries conName env)
 
 -------------------------------------------------------------------------------
 -- Lookup Utility Functions                                                  --
@@ -166,9 +166,9 @@ qualifyConEntry :: Environment a
                 -> ConEntry a
                 -> Maybe (ConEntry a)
 qualifyConEntry env qualInfo conEntry
-  = case ( qualifyQNameEnv interfaceTypeNames env qualInfo
+  = case ( qualifyQNameEnv interfaceConEntries env qualInfo
              (conEntryName conEntry)
-         , qualifyQNameEnv interfaceDataCons env qualInfo
+         , qualifyQNameEnv interfaceDataEntries env qualInfo
              (conEntryType conEntry)
          ) of
     (Just conName, Just typeName) ->

--- a/src/lib/HST/Environment.hs
+++ b/src/lib/HST/Environment.hs
@@ -55,7 +55,7 @@ lookupConEntries :: TypeName a
                  -> Environment a
                  -> [(Maybe (S.ModuleName a), Maybe [ConEntry a])]
 lookupConEntries typeName env = map
-  (qualifyLookupResult (\x -> mapM (qualifyConEntry env x)))
+  (qualifyLookupResult (mapM . qualifyConEntry env))
   (lookupWith interfaceDataCons typeName env)
 
 -- | Looks up the data type names belonging to the the given data constructor

--- a/src/lib/HST/Environment.hs
+++ b/src/lib/HST/Environment.hs
@@ -11,12 +11,11 @@ module HST.Environment
   , lookupTypeName
   ) where
 
-import           Data.Bifunctor            ( first, second )
-import           Data.Containers.ListUtils ( nubOrdOn )
+import           Data.Bifunctor            ( second )
 import           Data.List                 ( find )
 import           Data.Map.Strict           ( Map )
 import qualified Data.Map.Strict           as Map
-import           Data.Maybe                ( fromMaybe, mapMaybe, maybeToList )
+import           Data.Maybe                ( fromMaybe, mapMaybe )
 
 import           HST.Effect.InputModule
   ( ConEntry(..), ConName, DataEntry(..), ModuleInterface(..), TypeName )
@@ -31,7 +30,7 @@ data Environment a = Environment
   { envCurrentModule   :: ModuleInterface a
     -- ^ The module interface for the current module, containing its data types
     --   and data constructors.
-  , envImportedModules :: [(S.ImportDecl a, ModuleInterface a)]
+  , envImportedModules :: [([S.ImportDecl a], ModuleInterface a)]
     -- ^ A list of all successfully imported module interfaces including their
     --   import declarations. 
   , envOtherEntries    :: ModuleInterface a
@@ -84,26 +83,28 @@ lookupTypeName conName env = map
 -- | Looks up the given data type or constructor name in the maps gotten when
 --   applying the given function to the module interfaces in the given
 --   environment. In addition to the data type entries or constructor entries
---   found, the result includes the import declarations, where available, and
---   the module interfaces of the modules the found values came from.
+--   found, the result includes the import declarations and the module
+--   interfaces of the modules the found values came from.
 lookupWith :: (ModuleInterface a -> Map (S.QName a) v)
            -> S.QName a
            -> Environment a
-           -> [((Maybe (S.ImportDecl a), ModuleInterface a), v)]
+           -> [(([S.ImportDecl a], ModuleInterface a), v)]
 lookupWith getMap qName env = mapMaybe
   (\x -> fmap (x, ) (Map.lookup (S.unQualifyQName qName) (getMap (snd x))))
-  (nubOrdOn (interfaceModName . snd) (possibleInterfaces qName env))
+  (possibleInterfaces qName env)
 
 -- | Returns the list of all module interfaces in the given environment with
---   their import declarations, where available, that the given possibly
---   qualified name could refer to.
+--   their lists of import declarations, that the given possibly qualified name
+--   could refer to.
 possibleInterfaces :: S.QName a
                    -> Environment a
-                   -> [(Maybe (S.ImportDecl a), ModuleInterface a)]
-possibleInterfaces qName env = filter (fitsToInterface qName . snd)
-  [(Nothing, envCurrentModule env), (Nothing, envOtherEntries env)]
-  ++ map (first Just)
-  (filter (fitsToImport qName . fst) (envImportedModules env))
+                   -> [([S.ImportDecl a], ModuleInterface a)]
+possibleInterfaces qName env =
+  let defInterfaces    = filter (fitsToInterface qName . snd)
+        [([], envCurrentModule env), ([], envOtherEntries env)]
+      importInterfaces = filter (any (fitsToImport qName) . fst)
+        (envImportedModules env)
+  in defInterfaces ++ importInterfaces
  where
   -- | Checks if the given possibly qualified name could refer to an entry of
   --   the given module interface.
@@ -137,8 +138,8 @@ getImportQualifier importDecl = fromMaybe (S.importModule importDecl)
 --
 --   In addition to the qualified lookup result, the module name retrieved from
 --   the given qualification information is returned.
-qualifyLookupResult :: (Maybe (Bool, S.ModuleName a) -> b -> c)
-                    -> ((Maybe (S.ImportDecl a), ModuleInterface a), b)
+qualifyLookupResult :: (Maybe (Bool, [S.ModuleName a]) -> b -> c)
+                    -> (([S.ImportDecl a], ModuleInterface a), b)
                     -> (Maybe (S.ModuleName a), c)
 qualifyLookupResult qualify (qualInfo@(_, interface), lookupResult)
   = ( interfaceModName interface
@@ -146,24 +147,24 @@ qualifyLookupResult qualify (qualInfo@(_, interface), lookupResult)
     )
  where
   -- | Simplifies qualification information consisting of a module interface
-  --   and possibly an import declaration in the following way:
+  --   and a list of import declarations in the following way:
   --   If the qualification information does not specify a name, @Nothing@ is
   --   returned.
   --   Otherwise, a bool specifying whether identifiers must be qualified and
-  --   the module name that could be used as a qualifier are returned.
-  simplifyQualInfo :: (Maybe (S.ImportDecl a), ModuleInterface a)
-                   -> Maybe (Bool, S.ModuleName a)
-  simplifyQualInfo (Just importDecl, _)
-    = Just (S.importIsQual importDecl, getImportQualifier importDecl)
-  simplifyQualInfo (Nothing, interface') = fmap (False, )
+  --   the module names that could be used as a qualifier are returned.
+  simplifyQualInfo :: ([S.ImportDecl a], ModuleInterface a)
+                   -> Maybe (Bool, [S.ModuleName a])
+  simplifyQualInfo ([], interface') = fmap ((False, ) . (:[]))
     (interfaceModName interface')
+  simplifyQualInfo (imports, _)
+    = Just (all S.importIsQual imports, map getImportQualifier imports)
 
 -- | Qualifies the given data constructor entry based on the given
 --   qualification information so that neither the data constructor name nor
 --   the data type name of the constructor entry are ambiguous in the given
 --   environment. Returns @Nothing@ if that is not possible.
 qualifyConEntry :: Environment a
-                -> Maybe (Bool, S.ModuleName a)
+                -> Maybe (Bool, [S.ModuleName a])
                 -> ConEntry a
                 -> Maybe (ConEntry a)
 qualifyConEntry env qualInfo conEntry = do
@@ -179,12 +180,12 @@ qualifyConEntry env qualInfo conEntry = do
 --   specified by the given function. Returns @Nothing@ if that is not possible.
 qualifyQNameEnv :: (ModuleInterface a -> Map (S.QName a) v)
                 -> Environment a
-                -> Maybe (Bool, S.ModuleName a)
+                -> Maybe (Bool, [S.ModuleName a])
                 -> S.QName a
                 -> Maybe (S.QName a)
 qualifyQNameEnv getMap env qualInfo uqName
   = let mustBeQual          = maybe False fst qualInfo
-        modNames            = maybeToList (snd <$> qualInfo)
+        modNames            = maybe [] snd qualInfo
         qNames              = [uqName | not mustBeQual]
           ++ (qualifyQName uqName <$> modNames)
         isUnambigious qName = length (lookupWith getMap qName env) == 1

--- a/src/lib/HST/Environment.hs
+++ b/src/lib/HST/Environment.hs
@@ -50,11 +50,12 @@ data Environment a = Environment
 --   identified unambiguously.
 --   Returns multiple pairs of module names and constructor lists if the data
 --   type name is ambiguous.
-lookupConEntries
-  :: TypeName a -> Environment a -> [(Maybe (S.ModuleName a), Maybe [ConEntry a])]
-lookupConEntries typeName env =
-  map (qualifyLookupResult (\x -> sequence . map (qualifyConEntry env x)))
-      (lookupWith interfaceDataCons typeName env)
+lookupConEntries :: TypeName a
+                 -> Environment a
+                 -> [(Maybe (S.ModuleName a), Maybe [ConEntry a])]
+lookupConEntries typeName env = map
+  (qualifyLookupResult (\x -> sequence . map (qualifyConEntry env x)))
+  (lookupWith interfaceDataCons typeName env)
 
 -- | Looks up the data type names belonging to the the given data constructor
 --   name in the given environment and qualifies them so that they are
@@ -67,11 +68,12 @@ lookupConEntries typeName env =
 --   cannot be identified unambiguously.
 --   Returns multiple pairs of module and data type names if the data
 --   constructor name is ambiguous.
-lookupTypeName
-  :: ConName a -> Environment a -> [(Maybe (S.ModuleName a), Maybe (TypeName a))]
-lookupTypeName conName env =
-  map (qualifyLookupResult (qualifyQNameEnv interfaceDataCons env))
-      (lookupWith interfaceTypeNames conName env)
+lookupTypeName :: ConName a
+               -> Environment a
+               -> [(Maybe (S.ModuleName a), Maybe (TypeName a))]
+lookupTypeName conName env = map
+  (qualifyLookupResult (qualifyQNameEnv interfaceDataCons env))
+  (lookupWith interfaceTypeNames conName env)
 
 -------------------------------------------------------------------------------
 -- Lookup Utility Functions                                                  --
@@ -101,12 +103,13 @@ lookupWith getMap qName env = mapMaybe
 -- | Returns the list of all module interfaces in the given environment with
 --   their import declarations, where available, that the given possibly
 --   qualified name could refer to.
-possibleInterfaces
-  :: S.QName a -> Environment a -> [(Maybe (S.ImportDecl a), ModuleInterface a)]
+possibleInterfaces :: S.QName a
+                   -> Environment a
+                   -> [(Maybe (S.ImportDecl a), ModuleInterface a)]
 possibleInterfaces qName env = filter (fitsToInterface qName . snd)
   [(Nothing, envCurrentModule env), (Nothing, envOtherEntries env)]
   ++ map (\(x, y) -> (Just x, y))
-         (filter (fitsToImport qName . fst) (envImportedModules env))
+  (filter (fitsToImport qName . fst) (envImportedModules env))
  where
   -- | Checks if the given possibly qualified name could refer to an entry of
   --   the given module interface.
@@ -123,13 +126,13 @@ possibleInterfaces qName env = filter (fitsToInterface qName . snd)
   --   module imported with the given import declaration.
   fitsToImport :: S.QName a -> S.ImportDecl a -> Bool
   fitsToImport (S.Qual _ modName _) = (==) modName . getImportQualifier
-  fitsToImport _ = not . S.importIsQual
+  fitsToImport _                    = not . S.importIsQual
 
 -- | Gets the qualifier that identifiers referring to a module imported by the
 --   given import declaration are possibly qualified by.
 getImportQualifier :: S.ImportDecl a -> S.ModuleName a
-getImportQualifier importDecl =
-  fromMaybe (S.importModule importDecl) (S.importAsName importDecl)
+getImportQualifier importDecl = fromMaybe (S.importModule importDecl)
+  (S.importAsName importDecl)
 
 -------------------------------------------------------------------------------
 -- Qualification of Lookup Results                                           --
@@ -143,8 +146,10 @@ getImportQualifier importDecl =
 qualifyLookupResult :: (Maybe (Bool, S.ModuleName a) -> b -> c)
                     -> ((Maybe (S.ImportDecl a), ModuleInterface a), b)
                     -> (Maybe (S.ModuleName a), c)
-qualifyLookupResult qualify (qualInfo@(_, interface), lookupResult) =
-  (interfaceModName interface, qualify (simplifyQualInfo qualInfo) lookupResult)
+qualifyLookupResult qualify (qualInfo@(_, interface), lookupResult)
+  = ( interfaceModName interface
+    , qualify (simplifyQualInfo qualInfo) lookupResult
+    )
  where
   -- | Simplifies qualification information consisting of a module interface
   --   and possibly an import declaration in the following way:
@@ -154,24 +159,27 @@ qualifyLookupResult qualify (qualInfo@(_, interface), lookupResult) =
   --   the module name that could be used as a qualifier are returned.
   simplifyQualInfo :: (Maybe (S.ImportDecl a), ModuleInterface a)
                    -> Maybe (Bool, S.ModuleName a)
-  simplifyQualInfo (Just importDecl, _) =
-    Just (S.importIsQual importDecl, getImportQualifier importDecl)
-  simplifyQualInfo (Nothing, interface') =
-    fmap (False, ) (interfaceModName interface')
+  simplifyQualInfo (Just importDecl, _)
+    = Just (S.importIsQual importDecl, getImportQualifier importDecl)
+  simplifyQualInfo (Nothing, interface') = fmap (False, )
+    (interfaceModName interface')
 
 -- | Qualifies the given data constructor entry based on the given
 --   qualification information so that neither the data constructor name nor
 --   the data type name of the constructor entry are ambiguous in the given
 --   environment. Returns @Nothing@ if that is not possible.
-qualifyConEntry
-  :: Environment a -> Maybe (Bool, S.ModuleName a) -> ConEntry a -> Maybe (ConEntry a)
-qualifyConEntry env qualInfo conEntry =
-  case ( qualifyQNameEnv interfaceTypeNames env qualInfo (conEntryName conEntry)
-       , qualifyQNameEnv interfaceDataCons env qualInfo (conEntryType conEntry)
-       ) of
-    (Just conName, Just typeName) -> Just conEntry { conEntryName = conName
-                                                   , conEntryType = typeName
-                                                   }
+qualifyConEntry :: Environment a
+                -> Maybe (Bool, S.ModuleName a)
+                -> ConEntry a
+                -> Maybe (ConEntry a)
+qualifyConEntry env qualInfo conEntry
+  = case ( qualifyQNameEnv interfaceTypeNames env qualInfo
+             (conEntryName conEntry)
+         , qualifyQNameEnv interfaceDataCons env qualInfo
+             (conEntryType conEntry)
+         ) of
+    (Just conName, Just typeName) ->
+      Just conEntry { conEntryName = conName, conEntryType = typeName }
     _ -> Nothing
 
 -- | Qualifies the given possibly qualified name based on the given
@@ -183,10 +191,10 @@ qualifyQNameEnv :: (ModuleInterface a -> Map (S.QName a) v)
                 -> Maybe (Bool, S.ModuleName a)
                 -> S.QName a
                 -> Maybe (S.QName a)
-qualifyQNameEnv getMap env Nothing uqName = 
-  if length (lookupWith getMap uqName env) == 1 then Just uqName else Nothing
-qualifyQNameEnv getMap env (Just (mustBeQual, modName)) uqName =
-  if not mustBeQual && length (lookupWith getMap uqName env) == 1
+qualifyQNameEnv getMap env Nothing uqName
+  = if length (lookupWith getMap uqName env) == 1 then Just uqName else Nothing
+qualifyQNameEnv getMap env (Just (mustBeQual, modName)) uqName
+  = if not mustBeQual && length (lookupWith getMap uqName env) == 1
     then Just uqName
     else let qName = qualifyQName uqName modName
          in if length (lookupWith getMap qName env) == 1
@@ -199,4 +207,4 @@ qualifyQNameEnv getMap env (Just (mustBeQual, modName)) uqName =
   --   are returned as given.
   qualifyQName :: S.QName a -> S.ModuleName a -> S.QName a
   qualifyQName (S.UnQual s name) modName' = S.Qual s modName' name
-  qualifyQName qName _ = qName
+  qualifyQName qName _                    = qName

--- a/src/lib/HST/Environment.hs
+++ b/src/lib/HST/Environment.hs
@@ -10,6 +10,7 @@ module HST.Environment
   , lookupTypeName
   ) where
 
+import           Data.Map.Strict        ( Map )
 import qualified Data.Map.Strict        as Map
 import           Data.Maybe             ( fromMaybe, mapMaybe )
 
@@ -46,12 +47,7 @@ data Environment a = Environment
 --   is ambiguous.
 lookupConEntries
   :: TypeName a -> Environment a -> [(Maybe (S.ModuleName a), [ConEntry a])]
-lookupConEntries typeName env = mapMaybe
-  (\x ->
-   fmap (interfaceModName x, ) (Map.lookup typeName (interfaceDataCons x)))
-  (envCurrentModule env
-   : envOtherEntries env
-   : map snd (envImportedModules env))
+lookupConEntries = lookupWith interfaceDataCons
 
 -- | Looks up the data type names belonging to the the given data constructor
 --   name in the given environment. The result includes the names of the
@@ -62,18 +58,35 @@ lookupConEntries typeName env = mapMaybe
 --   is ambiguous.
 lookupTypeName
   :: ConName a -> Environment a -> [(Maybe (S.ModuleName a), TypeName a)]
-lookupTypeName conName env = mapMaybe
-  (\x ->
-   fmap (interfaceModName x, ) (Map.lookup conName (interfaceTypeNames x)))
-  (envCurrentModule env
-   : envOtherEntries env
-   : map snd (envImportedModules env))
+lookupTypeName = lookupWith interfaceTypeNames
 
 -------------------------------------------------------------------------------
 -- Lookup Utility Functions                                                  --
 -------------------------------------------------------------------------------
--- | Checks if the given qualified name could refer to an entry of the given
---   module interface.
+-- | A generic version of 'lookupConEntries' and 'lookupTypeName' that
+--   additionally takes a function mapping a module interface to the desired
+--   map, i. e. one of the field names of 'ModuleInterface', as its first
+--   argument.
+lookupWith :: (ModuleInterface a -> Map (S.QName a) v)
+           -> S.QName a
+           -> Environment a
+           -> [(Maybe (S.ModuleName a), v)]
+lookupWith getMap qName env = mapMaybe
+  (\i ->
+    fmap (interfaceModName i, ) (Map.lookup (unQualifyName qName) (getMap i)))
+  (possibleInterfaces qName env)
+
+-- | Returns the list of all module interfaces in the given environment the
+--   given possibly qualified name could refer to.
+possibleInterfaces :: S.QName a -> Environment a -> [ModuleInterface a]
+possibleInterfaces qName env =
+     filter
+       (fitsToInterface qName)
+       [envCurrentModule env, envOtherEntries env]
+  ++ map snd (filter (fitsToImport qName . fst) (envImportedModules env))
+
+-- | Checks if the given possibly qualified name could refer to an entry of the
+--   given module interface.
 --
 --   It is assumed that the given module interface is imported unqualified
 --   since it should either belong to the current module or implicitly imported
@@ -83,8 +96,8 @@ fitsToInterface :: S.QName a -> ModuleInterface a -> Bool
 fitsToInterface (S.Qual _ modName _) = elem modName . interfaceModName
 fitsToInterface _ = const True
 
--- | Checks if the given qualified name could refer to an entry of a module
---   imported with the given import declaration.
+-- | Checks if the given possibly qualified name could refer to an entry of a
+--   module imported with the given import declaration.
 fitsToImport :: S.QName a -> S.ImportDecl a -> Bool
 fitsToImport (S.Qual _ modName _) importDecl = modName ==
   fromMaybe (S.importModule importDecl) (S.importAsName importDecl)
@@ -92,7 +105,7 @@ fitsToImport _ importDecl = not (S.importIsQual importDecl)
 
 -- | Removes the possible qualification of the given 'S.QName'.
 --
---   Other 'S.QName's, including special names for built-in data constructors
+--   Other 'S.QName's, including special names for built-in data constructors,
 --   are returned as given.
 unQualifyName :: S.QName a -> S.QName a
 unQualifyName (S.Qual s _ name) = S.UnQual s name

--- a/src/lib/HST/Environment.hs
+++ b/src/lib/HST/Environment.hs
@@ -73,8 +73,8 @@ lookupTypeName :: ConName a
                -> Environment a
                -> [(Maybe (S.ModuleName a), Maybe (TypeName a))]
 lookupTypeName conName env = map
-  (qualifyLookupResult (qualifyQNameEnv interfaceDataEntries env) . second conEntryType)
-  (lookupWith interfaceConEntries conName env)
+  (qualifyLookupResult (qualifyQNameEnv interfaceDataEntries env)
+   . second conEntryType) (lookupWith interfaceConEntries conName env)
 
 -------------------------------------------------------------------------------
 -- Lookup Utility Functions                                                  --

--- a/src/lib/HST/Environment.hs
+++ b/src/lib/HST/Environment.hs
@@ -11,15 +11,15 @@ module HST.Environment
   , lookupTypeName
   ) where
 
-import           Data.Bifunctor            ( second )
-import           Data.List                 ( find )
-import           Data.Map.Strict           ( Map )
-import qualified Data.Map.Strict           as Map
-import           Data.Maybe                ( fromMaybe, mapMaybe )
+import           Data.Bifunctor         ( second )
+import           Data.List              ( find )
+import           Data.Map.Strict        ( Map )
+import qualified Data.Map.Strict        as Map
+import           Data.Maybe             ( fromMaybe, mapMaybe )
 
 import           HST.Effect.InputModule
   ( ConEntry(..), ConName, DataEntry(..), ModuleInterface(..), TypeName )
-import qualified HST.Frontend.Syntax       as S
+import qualified HST.Frontend.Syntax    as S
 
 -------------------------------------------------------------------------------
 -- Environment                                                               --
@@ -96,15 +96,14 @@ lookupWith getMap qName env = mapMaybe
 -- | Returns the list of all module interfaces in the given environment with
 --   their lists of import declarations, that the given possibly qualified name
 --   could refer to.
-possibleInterfaces :: S.QName a
-                   -> Environment a
-                   -> [([S.ImportDecl a], ModuleInterface a)]
-possibleInterfaces qName env =
-  let defInterfaces    = filter (fitsToInterface qName . snd)
-        [([], envCurrentModule env), ([], envOtherEntries env)]
-      importInterfaces = filter (any (fitsToImport qName) . fst)
-        (envImportedModules env)
-  in defInterfaces ++ importInterfaces
+possibleInterfaces
+  :: S.QName a -> Environment a -> [([S.ImportDecl a], ModuleInterface a)]
+possibleInterfaces qName env
+  = let defInterfaces    = filter (fitsToInterface qName . snd)
+          [([], envCurrentModule env), ([], envOtherEntries env)]
+        importInterfaces = filter (any (fitsToImport qName) . fst)
+          (envImportedModules env)
+    in defInterfaces ++ importInterfaces
  where
   -- | Checks if the given possibly qualified name could refer to an entry of
   --   the given module interface.
@@ -152,9 +151,9 @@ qualifyLookupResult qualify (qualInfo@(_, interface), lookupResult)
   --   returned.
   --   Otherwise, a bool specifying whether identifiers must be qualified and
   --   the module names that could be used as a qualifier are returned.
-  simplifyQualInfo :: ([S.ImportDecl a], ModuleInterface a)
-                   -> Maybe (Bool, [S.ModuleName a])
-  simplifyQualInfo ([], interface') = fmap ((False, ) . (:[]))
+  simplifyQualInfo
+    :: ([S.ImportDecl a], ModuleInterface a) -> Maybe (Bool, [S.ModuleName a])
+  simplifyQualInfo ([], interface') = fmap ((False, ) . (: []))
     (interfaceModName interface')
   simplifyQualInfo (imports, _)
     = Just (all S.importIsQual imports, map getImportQualifier imports)

--- a/src/lib/HST/Environment.hs
+++ b/src/lib/HST/Environment.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE TupleSections #-}
 
 -- | This module contains an abstract data type for the pattern matching
---   compiler's environment.
+--   compiler's environment and functions for looking up entries in this
+--   environment.
 module HST.Environment
   ( -- * Environment
     Environment(..)
@@ -38,13 +39,17 @@ data Environment a = Environment
 -------------------------------------------------------------------------------
 -- Lookup                                                                    --
 -------------------------------------------------------------------------------
--- | Looks up the constructors belonging to the the given data type name in the
---   given environment. The result includes the names of the modules the
---   constructors came from, if available.
+-- | Looks up the data constructor entries belonging to the the given data type
+--   name in the given environment and qualifies them so that they are
+--   unambiguous, if possible. The result includes the names of the modules
+--   the constructors came from, where available.
 --
 --   Returns an empty list if the data type name is not in scope.
---   Returns multiple module names and constructor lists if the data type name
---   is ambiguous.
+--   Returns a single pair with the second entry being @Nothing@ if the data
+--   type name is unambiguous, but not all of its constructors can be
+--   identified unambiguously.
+--   Returns multiple pairs of module names and constructor lists if the data
+--   type name is ambiguous.
 lookupConEntries
   :: TypeName a -> Environment a -> [(Maybe (S.ModuleName a), Maybe [ConEntry a])]
 lookupConEntries typeName env =
@@ -52,12 +57,16 @@ lookupConEntries typeName env =
       (lookupWith interfaceDataCons typeName env)
 
 -- | Looks up the data type names belonging to the the given data constructor
---   name in the given environment. The result includes the names of the
---   modules the types came from, if available.
+--   name in the given environment and qualifies them so that they are
+--   unambiguous, if possible. The result includes the names of the modules the
+--   types came from, where available.
 --
 --   Returns an empty list if the data constructor name is not in scope.
---   Returns multiple module and data type names if the data constructor name
---   is ambiguous.
+--   Returns a single pair with the second entry being @Nothing@ if the given
+--   data constructor name is unambiguous, but the data type it belongs to
+--   cannot be identified unambiguously.
+--   Returns multiple pairs of module and data type names if the data
+--   constructor name is ambiguous.
 lookupTypeName
   :: ConName a -> Environment a -> [(Maybe (S.ModuleName a), Maybe (TypeName a))]
 lookupTypeName conName env =
@@ -67,11 +76,12 @@ lookupTypeName conName env =
 -------------------------------------------------------------------------------
 -- Lookup Utility Functions                                                  --
 -------------------------------------------------------------------------------
--- TODO
--- | A generic version of 'lookupConEntries' and 'lookupTypeName' that
---   additionally takes a function mapping a module interface to the desired
---   map, i. e. one of the field names of 'ModuleInterface', as its first
---   argument.
+-- | Looks up the given data type or constructor name in the maps gotten when
+--   applying the given function to the module interfaces in the given
+--   environment. In addition to the lists of data constructor entries or data
+--   type names found, the result includes the import declarations, where
+--   available, and the module interfaces of the modules the found values came
+--   from.
 lookupWith :: (ModuleInterface a -> Map (S.QName a) v)
            -> S.QName a
            -> Environment a
@@ -79,59 +89,80 @@ lookupWith :: (ModuleInterface a -> Map (S.QName a) v)
 lookupWith getMap qName env = mapMaybe
   (\x -> fmap (x, ) (Map.lookup (unQualifyName qName) (getMap (snd x))))
   (possibleInterfaces qName env)
+ where
+  -- | Removes the possible qualification of the given 'S.QName'.
+  --
+  --   Other 'S.QName's, including special names for built-in data
+  --   constructors, are returned as given.
+  unQualifyName :: S.QName a -> S.QName a
+  unQualifyName (S.Qual s _ name) = S.UnQual s name
+  unQualifyName uqName            = uqName
 
--- TODO
--- | Returns the list of all module interfaces in the given environment the
---   given possibly qualified name could refer to.
+-- | Returns the list of all module interfaces in the given environment with
+--   their import declarations, where available, that the given possibly
+--   qualified name could refer to.
 possibleInterfaces
   :: S.QName a -> Environment a -> [(Maybe (S.ImportDecl a), ModuleInterface a)]
 possibleInterfaces qName env = filter (fitsToInterface qName . snd)
   [(Nothing, envCurrentModule env), (Nothing, envOtherEntries env)]
   ++ map (\(x, y) -> (Just x, y))
          (filter (fitsToImport qName . fst) (envImportedModules env))
+ where
+  -- | Checks if the given possibly qualified name could refer to an entry of
+  --   the given module interface.
+  --
+  --   It is assumed that the given module interface is imported unqualified
+  --   since it should either belong to the current module or implicitly
+  --   imported modules. It therefore returns @True@ for names qualified with
+  --   the module interface name and all unqualified names.
+  fitsToInterface :: S.QName a -> ModuleInterface a -> Bool
+  fitsToInterface (S.Qual _ modName _) = elem modName . interfaceModName
+  fitsToInterface _                    = const True
 
--- | Checks if the given possibly qualified name could refer to an entry of the
---   given module interface.
---
---   It is assumed that the given module interface is imported unqualified
---   since it should either belong to the current module or implicitly imported
---   modules. It therefore returns @True@ for names qualified with the module
---   interface name and all unqualified names.
-fitsToInterface :: S.QName a -> ModuleInterface a -> Bool
-fitsToInterface (S.Qual _ modName _) = elem modName . interfaceModName
-fitsToInterface _                    = const True
+  -- | Checks if the given possibly qualified name could refer to an entry of a
+  --   module imported with the given import declaration.
+  fitsToImport :: S.QName a -> S.ImportDecl a -> Bool
+  fitsToImport (S.Qual _ modName _) = (==) modName . getImportQualifier
+  fitsToImport _ = not . S.importIsQual
 
--- | Checks if the given possibly qualified name could refer to an entry of a
---   module imported with the given import declaration.
-fitsToImport :: S.QName a -> S.ImportDecl a -> Bool
-fitsToImport (S.Qual _ modName _) = (==) modName . getImportQualifier
-fitsToImport _ = not . S.importIsQual
-
+-- | Gets the qualifier that identifiers referring to a module imported by the
+--   given import declaration are possibly qualified by.
 getImportQualifier :: S.ImportDecl a -> S.ModuleName a
 getImportQualifier importDecl =
   fromMaybe (S.importModule importDecl) (S.importAsName importDecl)
 
--- | Removes the possible qualification of the given 'S.QName'.
+-------------------------------------------------------------------------------
+-- Qualification of Lookup Results                                           --
+-------------------------------------------------------------------------------
+-- | Uses the given qualification function (first argument) and the given
+--   qualification information (first element of the second argument) to
+--   qualify the given lookup result (second element of the second argument).
 --
---   Other 'S.QName's, including special names for built-in data constructors,
---   are returned as given.
-unQualifyName :: S.QName a -> S.QName a
-unQualifyName (S.Qual s _ name) = S.UnQual s name
-unQualifyName uqName            = uqName
-
+--   In addition to the qualified lookup result, the module name retrieved from
+--   the given qualification information is returned.
 qualifyLookupResult :: (Maybe (Bool, S.ModuleName a) -> b -> c)
                     -> ((Maybe (S.ImportDecl a), ModuleInterface a), b)
                     -> (Maybe (S.ModuleName a), c)
 qualifyLookupResult qualify (qualInfo@(_, interface), lookupResult) =
-  (interfaceModName interface, qualify (transformQualInfo qualInfo) lookupResult)
+  (interfaceModName interface, qualify (simplifyQualInfo qualInfo) lookupResult)
  where
-  transformQualInfo :: (Maybe (S.ImportDecl a), ModuleInterface a)
-                    -> Maybe (Bool, S.ModuleName a)
-  transformQualInfo (Just importDecl, _) =
+  -- | Simplifies qualification information consisting of a module interface
+  --   and possibly an import declaration in the following way:
+  --   If the qualification information does not specify a name, @Nothing@ is
+  --   returned.
+  --   Otherwise, a bool specifying whether identifiers must be qualified and
+  --   the module name that could be used as a qualifier are returned.
+  simplifyQualInfo :: (Maybe (S.ImportDecl a), ModuleInterface a)
+                   -> Maybe (Bool, S.ModuleName a)
+  simplifyQualInfo (Just importDecl, _) =
     Just (S.importIsQual importDecl, getImportQualifier importDecl)
-  transformQualInfo (Nothing, interface') =
+  simplifyQualInfo (Nothing, interface') =
     fmap (False, ) (interfaceModName interface')
 
+-- | Qualifies the given data constructor entry based on the given
+--   qualification information so that neither the data constructor name nor
+--   the data type name of the constructor entry are ambiguous in the given
+--   environment. Returns @Nothing@ if that is not possible.
 qualifyConEntry
   :: Environment a -> Maybe (Bool, S.ModuleName a) -> ConEntry a -> Maybe (ConEntry a)
 qualifyConEntry env qualInfo conEntry =
@@ -143,6 +174,10 @@ qualifyConEntry env qualInfo conEntry =
                                                    }
     _ -> Nothing
 
+-- | Qualifies the given possibly qualified name based on the given
+--   qualification information so that it is not ambiguous in its namespace of
+--   the given environment, where the namespace (data types or constructors) is
+--   specified by the given function. Returns @Nothing@ if that is not possible.
 qualifyQNameEnv :: (ModuleInterface a -> Map (S.QName a) v)
                 -> Environment a
                 -> Maybe (Bool, S.ModuleName a)
@@ -157,7 +192,11 @@ qualifyQNameEnv getMap env (Just (mustBeQual, modName)) uqName =
          in if length (lookupWith getMap qName env) == 1
               then Just qName
               else Nothing
-
-qualifyQName :: S.QName a -> S.ModuleName a -> S.QName a
-qualifyQName (S.UnQual s name) modName = S.Qual s modName name
-qualifyQName qName _ = qName
+ where
+  -- | Qualifies the given unqualified 'S.QName' by the given module name.
+  --
+  --   Already qualified names and special names for built-in data constructors
+  --   are returned as given.
+  qualifyQName :: S.QName a -> S.ModuleName a -> S.QName a
+  qualifyQName (S.UnQual s name) modName' = S.Qual s modName' name
+  qualifyQName qName _ = qName

--- a/src/lib/HST/Environment.hs
+++ b/src/lib/HST/Environment.hs
@@ -12,6 +12,7 @@ module HST.Environment
   ) where
 
 import           Data.Bifunctor         ( first, second )
+import           Data.Containers.ListUtils ( nubOrdOn )
 import           Data.List              ( find )
 import           Data.Map.Strict        ( Map )
 import qualified Data.Map.Strict        as Map
@@ -91,7 +92,7 @@ lookupWith :: (ModuleInterface a -> Map (S.QName a) v)
            -> [((Maybe (S.ImportDecl a), ModuleInterface a), v)]
 lookupWith getMap qName env = mapMaybe
   (\x -> fmap (x, ) (Map.lookup (S.unQualifyQName qName) (getMap (snd x))))
-  (possibleInterfaces qName env)
+  (nubOrdOn (interfaceModName . snd) (possibleInterfaces qName env))
 
 -- | Returns the list of all module interfaces in the given environment with
 --   their import declarations, where available, that the given possibly

--- a/src/lib/HST/Environment/LookupOrReport.hs
+++ b/src/lib/HST/Environment/LookupOrReport.hs
@@ -1,8 +1,10 @@
 -- | This module contains variations of the "HST.Environment" lookup functions
---   that remove the list and pair constructor wrapping the return type.
+--   that remove the list, pair and @Maybe@ type wrapping the desired return
+--   type.
 --
---   If the original function does not return a singleton list, a fatal error
---   mentioning the out-of-scope or ambiguous entry is reported.
+--   If the original lookup function does not return a singleton list
+--   containing @Just@ the desired return type, a fatal error mentioning the
+--   problem case is reported.
 module HST.Environment.LookupOrReport
   ( lookupConEntriesOrReport
   , lookupTypeNameOrReport
@@ -19,12 +21,15 @@ import qualified HST.Frontend.Syntax    as S
 import           HST.Util.Messages      ( Severity(Error), message )
 import           HST.Util.PrettyName    ( prettyName )
 
--- | Looks up the constructors belonging to the the given data type name in the
---   current environment.
+-- | Looks up the data constructor entries belonging to the the given data type
+--   name in the current environment and qualifies them so that they are
+--   unambiguous.
 --
 --   Reports a fatal error if the data type could not be found or if it could
 --   be found in multiple modules. In the latter case, the names of
---   these modules are displayed as part of the error message.
+--   these modules are displayed as part of the error message. A fatal error is
+--   also reported if not all constructors found could be identified
+--   unambiguously.
 lookupConEntriesOrReport
   :: Members '[Env a, Report] r => TypeName a -> Sem r [ConEntry a]
 lookupConEntriesOrReport typeName = do
@@ -47,12 +52,14 @@ lookupConEntriesOrReport typeName = do
       ++ "` could refer to one of the following modules: "
       ++ displayModuleNames conEntriess
 
--- | Looks up the data type names belonging to the the given data constructor
---   name in the current environment.
+-- | Looks up the data type name belonging to the the given data constructor
+--   name in the current environment and qualifies it so that it is
+--   unambiguous.
 --
 --   Reports a fatal error if the data constructor could not be found or if it
 --   could be found in multiple modules. In the latter case, the names of these
---   modules are displayed as part of the error message.
+--   modules are displayed as part of the error message. A fatal error is also
+--   reported if the data type found could not be identified unambiguously.
 lookupTypeNameOrReport
   :: Members '[Env a, Report] r => ConName a -> Sem r (TypeName a)
 lookupTypeNameOrReport conName = do
@@ -75,7 +82,7 @@ lookupTypeNameOrReport conName = do
       ++ "` could refer to one of the following modules: "
       ++ displayModuleNames typeNames
 
--- | Display the module names contained in the first pair entries of the given
+-- | Displays the module names contained in the first pair entries of the given
 --   list.
 --
 --   As no modules without a module name should be able to be imported

--- a/src/lib/HST/Environment/LookupOrReport.hs
+++ b/src/lib/HST/Environment/LookupOrReport.hs
@@ -33,7 +33,13 @@ lookupConEntriesOrReport typeName = do
     []                -> reportFatal
       $ message Error (S.getSrcSpan typeName)
       $ "Data type not in scope: " ++ prettyName typeName
-    [(_, conEntries)] -> return conEntries
+    [(_, Nothing)] -> reportFatal
+      $ message Error (S.getSrcSpan typeName)
+      $ "Constructor entries for the data type `"
+      ++ prettyName typeName
+      ++ "` could not be returned, because at least one of them cannot be "
+      ++ "identified unambiguously."
+    [(_, Just conEntries)] -> return conEntries
     _                 -> reportFatal
       $ message Error (S.getSrcSpan typeName)
       $ "Ambiguous data type `"
@@ -55,7 +61,13 @@ lookupTypeNameOrReport conName = do
     []              -> reportFatal
       $ message Error (S.getSrcSpan conName)
       $ "Data constructor not in scope: " ++ prettyName conName
-    [(_, typeName)] -> return typeName
+    [(_, Nothing)] -> reportFatal
+      $ message Error (S.getSrcSpan conName)
+      $ "The name of the data type that the constructor `"
+      ++ prettyName conName
+      ++ "` belongs to could not be returned, because it cannot be identified "
+      ++ "unambiguously."
+    [(_, Just typeName)] -> return typeName
     _               -> reportFatal
       $ message Error (S.getSrcSpan conName)
       $ "Ambiguous data constructor `"

--- a/src/lib/HST/Environment/LookupOrReport.hs
+++ b/src/lib/HST/Environment/LookupOrReport.hs
@@ -35,7 +35,7 @@ lookupConEntriesOrReport
 lookupConEntriesOrReport typeName = do
   conEntriess <- inEnv $ lookupConEntries typeName
   case conEntriess of
-    []                -> reportFatal
+    [] -> reportFatal
       $ message Error (S.getSrcSpan typeName)
       $ "Data type not in scope: " ++ prettyName typeName
     [(_, Nothing)] -> reportFatal
@@ -45,7 +45,7 @@ lookupConEntriesOrReport typeName = do
       ++ "` could not be returned, because at least one of them cannot be "
       ++ "identified unambiguously."
     [(_, Just conEntries)] -> return conEntries
-    _                 -> reportFatal
+    _ -> reportFatal
       $ message Error (S.getSrcSpan typeName)
       $ "Ambiguous data type `"
       ++ prettyName typeName
@@ -65,17 +65,17 @@ lookupTypeNameOrReport
 lookupTypeNameOrReport conName = do
   typeNames <- inEnv $ lookupTypeName conName
   case typeNames of
-    []              -> reportFatal
+    []                   -> reportFatal
       $ message Error (S.getSrcSpan conName)
       $ "Data constructor not in scope: " ++ prettyName conName
-    [(_, Nothing)] -> reportFatal
+    [(_, Nothing)]       -> reportFatal
       $ message Error (S.getSrcSpan conName)
       $ "The name of the data type that the constructor `"
       ++ prettyName conName
       ++ "` belongs to could not be returned, because it cannot be identified "
       ++ "unambiguously."
     [(_, Just typeName)] -> return typeName
-    _               -> reportFatal
+    _                    -> reportFatal
       $ message Error (S.getSrcSpan conName)
       $ "Ambiguous data constructor `"
       ++ prettyName conName

--- a/src/lib/HST/Feature/Optimization.hs
+++ b/src/lib/HST/Feature/Optimization.hs
@@ -123,7 +123,7 @@ altMatchesPat alt pat = do
   return (patConName `cheatEq` altConName)
 
 -- | Compares the given 'S.QName's ignoring the distinction between 'S.Ident's
---   and 'S.Symbol's, i.e. @S.Ident "+:"@ and @S.Symbol "+:"@ are equal. 
+--   and 'S.Symbol's, i.e. @S.Ident "+:"@ and @S.Symbol "+:"@ are equal.
 cheatEq :: S.QName a -> S.QName a -> Bool
 cheatEq (S.UnQual _ (S.Symbol _ s1)) (S.UnQual _ (S.Ident _ s2)) = s1 == s2
 cheatEq (S.UnQual _ (S.Ident _ s1)) (S.UnQual _ (S.Symbol _ s2)) = s1 == s2

--- a/src/lib/HST/Feature/Optimization.hs
+++ b/src/lib/HST/Feature/Optimization.hs
@@ -109,15 +109,18 @@ renameAndOpt pat alts = do
       optimize' expr'
 
 -- | Tests whether the given alternative matches the given pattern.
+--
+--   It is assumed that the alternative and the pattern belong to the same data
+--   type.
 altMatchesPat :: Member Report r => S.Alt a -> S.Pat a -> Sem r Bool
 altMatchesPat alt pat = do
   -- TODO we actually need to unify the patterns here.
-  patConName <- getPatConName pat
-  altConName <- getAltConName alt
+  patConName <- S.unQualifyQName <$> getPatConName pat
+  altConName <- S.unQualifyQName <$> getAltConName alt
   return (patConName `cheatEq` altConName)
 
 -- | Compares the given 'S.QName's ignoring the distinction between 'S.Ident's
---   and 'S.Symbol's, i.e. @S.Ident "+:"@ amd @S.Symbol "+:"@ are equal.
+--   and 'S.Symbol's, i.e. @S.Ident "+:"@ and @S.Symbol "+:"@ are equal. 
 cheatEq :: S.QName a -> S.QName a -> Bool
 cheatEq (S.UnQual _ (S.Symbol _ s1)) (S.UnQual _ (S.Ident _ s2)) = s1 == s2
 cheatEq (S.UnQual _ (S.Ident _ s1)) (S.UnQual _ (S.Symbol _ s2)) = s1 == s2

--- a/src/lib/HST/Frontend/Syntax.hs
+++ b/src/lib/HST/Frontend/Syntax.hs
@@ -398,6 +398,18 @@ instance HasSrcSpan QName where
 instance QNameLike QName where
   toQName = id
 
+-- | Compares the given 'QName's ignoring their possible qualification.
+eqUnQual :: QName a -> QName a -> Bool
+eqUnQual qName1 qName2 = unQualifyQName qName1 == unQualifyQName qName2
+
+-- | Removes the possible qualification of the given 'QName'.
+--
+--   Other 'QName's, including special names for built-in data
+--   constructors, are returned as given.
+unQualifyQName :: QName a -> QName a
+unQualifyQName (Qual s _ name) = UnQual s name
+unQualifyQName uqName          = uqName
+
 -- | An unqualified name.
 data Name a = Ident (SrcSpan a) String | Symbol (SrcSpan a) String
  deriving ( Eq, Ord )

--- a/src/test/HST/Effect/SetExpectation.hs
+++ b/src/test/HST/Effect/SetExpectation.hs
@@ -30,7 +30,7 @@ import           HST.Util.Messages ( showPrettyMessage )
 -------------------------------------------------------------------------------
 -- Effect and Actions                                                        --
 -------------------------------------------------------------------------------
--- | Effect cabable of setting 'Expectation's in computations.
+-- | Effect capable of setting 'Expectation's in computations.
 data SetExpectation m a where
   SetExpectation :: Expectation -> SetExpectation m ()
   AssertFailure :: String -> SetExpectation m a

--- a/src/test/HST/EnvironmentTests.hs
+++ b/src/test/HST/EnvironmentTests.hs
@@ -5,15 +5,17 @@ module HST.EnvironmentTests ( testEnvironment ) where
 
 import           Data.Bifunctor            ( second )
 import           Polysemy                  ( Member, Members, Sem )
-import           Test.Hspec                ( Spec, context, describe, it, shouldBe )
+import           Test.Hspec
+  ( Spec, context, describe, it, shouldBe )
 
 import           HST.Application           ( createModuleInterface )
 import           HST.Effect.Cancel         ( Cancel )
-import           HST.Effect.InputModule    ( ConName, ConEntry(..), TypeName )
+import           HST.Effect.InputModule    ( ConEntry(..), ConName, TypeName )
 import           HST.Effect.Report         ( Report )
 import           HST.Effect.SetExpectation ( SetExpectation, setExpectation )
 import           HST.Effect.WithFrontend   ( WithFrontend )
-import           HST.Environment           ( Environment(..), lookupConEntries, lookupTypeName )
+import           HST.Environment
+  ( Environment(..), lookupConEntries, lookupTypeName )
 import           HST.Environment.Prelude   ( preludeModuleInterface )
 import qualified HST.Frontend.Syntax       as S
 import           HST.Test.Parser           ( parseTestModule )
@@ -28,8 +30,8 @@ typeNameShouldBe :: (S.ShowAST a, Member SetExpectation r)
                  => [(Maybe (S.ModuleName a), Maybe (TypeName a))]
                  -> [(Maybe (S.ModuleName a), Maybe (TypeName a))]
                  -> Sem r ()
-typeNameShouldBe lookupResult expectedResult = setExpectation $
-  lookupResult `shouldBe` expectedResult
+typeNameShouldBe lookupResult expectedResult
+  = setExpectation $ lookupResult `shouldBe` expectedResult
 
 -- | Sets the expectation that the given lists of module names and (partial)
 --   constructor entries are equal after unifying their structure.
@@ -37,9 +39,10 @@ conEntriesShouldBe :: (S.ShowAST a, Member SetExpectation r)
                    => [(Maybe (S.ModuleName a), Maybe [ConEntry a])]
                    -> [(Maybe (S.ModuleName a), (TypeName a, [ConName a]))]
                    -> Sem r ()
-conEntriesShouldBe lookupResult expectedResult = setExpectation $
-  map (second (maybe [] (map transformConEntry))) lookupResult `shouldBe`
-    map (second (\(typeName, cons) -> map (, typeName) cons)) expectedResult
+conEntriesShouldBe lookupResult expectedResult = setExpectation
+  $ map (second (maybe [] (map transformConEntry))) lookupResult
+  `shouldBe` map (second (\(typeName, cons) -> map (, typeName) cons))
+  expectedResult
  where
   -- | Transforms a constructor entry to a pair of its own and its type's name.
   transformConEntry :: ConEntry a -> (ConName a, TypeName a)
@@ -86,9 +89,9 @@ qName :: String -- ^ The module name the name is qualified by. An empty string
       -> String -- ^ The name without its possible qualification. It is assumed
                 --   that this is a regular identifier and not a symbol.
       -> S.QName a
-qName "" name = S.UnQual S.NoSrcSpan (S.Ident S.NoSrcSpan name)
-qName modul name =
-  S.Qual S.NoSrcSpan (S.ModuleName S.NoSrcSpan modul) (S.Ident S.NoSrcSpan name)
+qName "" name    = S.UnQual S.NoSrcSpan (S.Ident S.NoSrcSpan name)
+qName modul name = S.Qual S.NoSrcSpan (S.ModuleName S.NoSrcSpan modul)
+  (S.Ident S.NoSrcSpan name)
 
 -- | Creates a module name based on the given name.
 moduleName :: String -> Maybe (S.ModuleName a)
@@ -100,27 +103,19 @@ moduleName modName = Just $ S.ModuleName S.NoSrcSpan modName
 -------------------------------------------------------------------------------
 -- | Lines of the test module @modA@.
 modA :: [String]
-modA = [ "module A where"
-       , "data Foo = Bar | Baz"
-       ]
+modA = ["module A where", "data Foo = Bar | Baz"]
 
 -- | Lines of the test module @modB@.
 modB :: [String]
-modB = [ "module B where"
-       , "data FooB = BarB | Baz"
-       ]
+modB = ["module B where", "data FooB = BarB | Baz"]
 
 -- | Lines of the test module @modC@.
 modC :: [String]
-modC = [ "module C where"
-       , "data Foo = Bar | BazC"
-       ]
+modC = ["module C where", "data Foo = Bar | BazC"]
 
 -- | Lines of the test module @modD@.
 modD :: [String]
-modD = [ "module D where"
-       , "data Bar = Foo | Baz"
-       ]
+modD = ["module D where", "data Bar = Foo | Baz"]
 
 -- | Lines of the test module @modUnnamed@.
 modUnnamed :: [String]
@@ -132,159 +127,176 @@ modUnnamed = ["data Foo = BarUnnamed"]
 -- | Test group for "HST.Environment".
 testEnvironment :: Spec
 testEnvironment = describe "HST.Environment" $ do
- context "with unqualified lookups" $ do
-  it "finds a type name in the current module" $
-    runTest $ do
+  context "with unqualified lookups" $ do
+    it "finds a type name in the current module" $ runTest $ do
       env <- setupTestEnvironment modA [] []
       let query     = lookupTypeName (qName "" "Bar") env
           expResult = [(moduleName "A", Just (qName "" "Foo"))]
       query `typeNameShouldBe` expResult
-  it "finds constructor entries in an imported module" $
-    runTest $ do
+    it "finds constructor entries in an imported module" $ runTest $ do
       env <- setupTestEnvironment [""] [[importDecl "A" False ""]] [modA]
       let query     = lookupConEntries (qName "" "Foo") env
-          expResult = [(moduleName "A",
-                       (qName "" "Foo", [qName "" "Bar", qName "" "Baz"]))]
+          expResult = [ ( moduleName "A"
+                          , (qName "" "Foo", [qName "" "Bar", qName "" "Baz"])
+                          )
+                      ]
       query `conEntriesShouldBe` expResult
-  it "finds type names for built-in types" $
-    runTest $ do
+    it "finds type names for built-in types" $ runTest $ do
       env <- setupTestEnvironment modA [] []
       let unitCon   = S.Special S.NoSrcSpan (S.UnitCon S.NoSrcSpan)
           query     = lookupTypeName unitCon env
           expResult = [(moduleName "Prelude", Just unitCon)]
       query `typeNameShouldBe` expResult
-  it "does not search in type names when supposedly given a constructor name" $
-    runTest $ do
-      env <- setupTestEnvironment modA [] []
-      let query     = lookupTypeName (qName "" "Foo") env
-          expResult = []
-      query `typeNameShouldBe` expResult
-  it "does not search in constructor names when supposedly given a type name" $
-    runTest $ do
-      env <- setupTestEnvironment modA [] []
-      let query     = lookupConEntries (qName "" "Bar") env
-          expResult = []
-      query `conEntriesShouldBe` expResult
-  it "does not search for unqualified identifiers in qualified imports" $
-    runTest $ do
-      env <- setupTestEnvironment [""] [[importDecl "A" True ""]] [modA]
-      let query     = lookupTypeName (qName "" "Bar") env
-          expResult = []
-      query `typeNameShouldBe` expResult
-
- context "with qualified lookups" $ do
-  it "searches for qualified identifiers only in the respective modules" $
-    runTest $ do
-      env <- setupTestEnvironment [""]
-        [[importDecl "A" False ""], [importDecl "B" False ""]] [modA, modB]
-      let query     = lookupTypeName (qName "B" "Baz") env
-          expResult = [(moduleName "B", Just (qName "" "FooB"))]
-      query `typeNameShouldBe` expResult
-  it "searches in the current module for identifiers qualified with its name" $
-    runTest $ do
-      env <- setupTestEnvironment modA [[importDecl "B" False ""]] [modB]
-      let query     = lookupTypeName (qName "A" "Baz") env
-          expResult = [(moduleName "A", Just (qName "" "Foo"))]
-      query `typeNameShouldBe` expResult
-  it "does search in aliased imports by their alias name" $
-    runTest $ do
+    it "does not search in type names when supposedly given a constructor name"
+      $ runTest
+      $ do
+        env <- setupTestEnvironment modA [] []
+        let query     = lookupTypeName (qName "" "Foo") env
+            expResult = []
+        query `typeNameShouldBe` expResult
+    it "does not search in constructor names when supposedly given a type name"
+      $ runTest
+      $ do
+        env <- setupTestEnvironment modA [] []
+        let query     = lookupConEntries (qName "" "Bar") env
+            expResult = []
+        query `conEntriesShouldBe` expResult
+    it "does not search for unqualified identifiers in qualified imports"
+      $ runTest
+      $ do
+        env <- setupTestEnvironment [""] [[importDecl "A" True ""]] [modA]
+        let query     = lookupTypeName (qName "" "Bar") env
+            expResult = []
+        query `typeNameShouldBe` expResult
+  context "with qualified lookups" $ do
+    it "searches for qualified identifiers only in the respective modules"
+      $ runTest
+      $ do
+        env <- setupTestEnvironment [""]
+          [[importDecl "A" False ""], [importDecl "B" False ""]] [modA, modB]
+        let query     = lookupTypeName (qName "B" "Baz") env
+            expResult = [(moduleName "B", Just (qName "" "FooB"))]
+        query `typeNameShouldBe` expResult
+    it "searches in the current module for identifiers qualified with its name"
+      $ runTest
+      $ do
+        env <- setupTestEnvironment modA [[importDecl "B" False ""]] [modB]
+        let query     = lookupTypeName (qName "A" "Baz") env
+            expResult = [(moduleName "A", Just (qName "" "Foo"))]
+        query `typeNameShouldBe` expResult
+    it "does search in aliased imports by their alias name" $ runTest $ do
       env <- setupTestEnvironment [""] [[importDecl "A" False "C"]] [modA]
       let query     = lookupTypeName (qName "C" "Bar") env
           expResult = [(moduleName "A", Just (qName "" "Foo"))]
       query `typeNameShouldBe` expResult
-  it "does not search in aliased imports by their original name" $
-    runTest $ do
+    it "does not search in aliased imports by their original name" $ runTest $ do
       env <- setupTestEnvironment [""] [[importDecl "A" False "C"]] [modA]
       let query     = lookupTypeName (qName "A" "Bar") env
           expResult = []
       query `typeNameShouldBe` expResult
-  it "qualifies lookup results coming from qualified imports" $
-    runTest $ do
+    it "qualifies lookup results coming from qualified imports" $ runTest $ do
       env <- setupTestEnvironment [""] [[importDecl "A" True ""]] [modA]
       let query     = lookupTypeName (qName "A" "Bar") env
           expResult = [(moduleName "A", Just (qName "A" "Foo"))]
       query `typeNameShouldBe` expResult
-
- context "with ambiguous lookups or multiple qualification options" $ do
-  it "returns multiple results for ambiguous identifiers" $
-    runTest $ do
+  context "with ambiguous lookups or multiple qualification options" $ do
+    it "returns multiple results for ambiguous identifiers" $ runTest $ do
       env <- setupTestEnvironment [""]
         [[importDecl "A" False ""], [importDecl "B" False ""]] [modA, modB]
       let query     = lookupTypeName (qName "" "Baz") env
-          expResult = [(moduleName "A", Just (qName "" "Foo")),
-                       (moduleName "B", Just (qName "" "FooB"))]
+          expResult = [ (moduleName "A", Just (qName "" "Foo"))
+                      , (moduleName "B", Just (qName "" "FooB"))
+                      ]
       query `typeNameShouldBe` expResult
-  it "qualifies a result with an imported module's name if necessary" $
-    runTest $ do
-      env <- setupTestEnvironment [""]
-        [[importDecl "A" False ""], [importDecl "C" False ""]] [modA, modC]
-      let query     = lookupTypeName (qName "" "BazC") env
-          expResult = [(moduleName "C", Just (qName "C" "Foo"))]
-      query `typeNameShouldBe` expResult
-  it "qualifies a result with the current module's name if necessary" $
-    runTest $ do
-      env <- setupTestEnvironment modA [[importDecl "C" False ""]] [modC]
-      let query     = lookupTypeName (qName "" "Baz") env
-          expResult = [(moduleName "A", Just (qName "A" "Foo"))]
-      query `typeNameShouldBe` expResult
-  it "does not try to qualify a result by an unnamed module" $
-    runTest $ do
+    it "qualifies a result with an imported module's name if necessary"
+      $ runTest
+      $ do
+        env <- setupTestEnvironment [""]
+          [[importDecl "A" False ""], [importDecl "C" False ""]] [modA, modC]
+        let query     = lookupTypeName (qName "" "BazC") env
+            expResult = [(moduleName "C", Just (qName "C" "Foo"))]
+        query `typeNameShouldBe` expResult
+    it "qualifies a result with the current module's name if necessary"
+      $ runTest
+      $ do
+        env <- setupTestEnvironment modA [[importDecl "C" False ""]] [modC]
+        let query     = lookupTypeName (qName "" "Baz") env
+            expResult = [(moduleName "A", Just (qName "A" "Foo"))]
+        query `typeNameShouldBe` expResult
+    it "does not try to qualify a result by an unnamed module" $ runTest $ do
       env <- setupTestEnvironment modUnnamed [[importDecl "A" False ""]] [modA]
       let query     = lookupTypeName (qName "" "BarUnnamed") env
           expResult = [(moduleName "", Nothing)]
       query `typeNameShouldBe` expResult
-  it "returns an unqualified identifier if necessary" $
-    runTest $ do
+    it "returns an unqualified identifier if necessary" $ runTest $ do
       env <- setupTestEnvironment modA [[importDecl "C" True "A"]] [modC]
       let query     = lookupTypeName (qName "A" "Baz") env
           expResult = [(moduleName "A", Just (qName "" "Foo"))]
       query `typeNameShouldBe` expResult
-  it "only qualifies the parts of the result that need qualification" $
-    runTest $ do
-      env <- setupTestEnvironment modA [[importDecl "C" False ""]] [modC]
-      let query     = lookupConEntries (qName "A" "Foo") env
-          expResult = [(moduleName "A",
-                       (qName "A" "Foo", [qName "A" "Bar", qName "" "Baz"]))]
-      query `conEntriesShouldBe` expResult
-  it ("does not return any constructors if a single one cannot be "
-    ++ "identified unambiguously") $
-    runTest $ do
-      env <- setupTestEnvironment modA [[importDecl "B" False "A"]] [modB]
-      let query     = lookupConEntries (qName "" "Foo") env
-          expResult = [(moduleName "A", (qName "" "", []))]
-      query `conEntriesShouldBe` expResult
-  it "ignores name clashes between data type and constructor names" $
-    runTest $ do
-      env <- setupTestEnvironment modA [[importDecl "D" False ""]] [modD]
-      let query     = lookupConEntries (qName "" "Bar") env
-          expResult = [(moduleName "D",
-                       (qName "" "Bar", [qName "" "Foo", qName "D" "Baz"]))]
-      query `conEntriesShouldBe` expResult
-
- context "with multiple import declarations for the same modules" $ do
-  it ("does not consider identifiers fitting to multiple import "
-    ++ "declarations ambiguous if they all refer to the same module") $
-    runTest $ do
-      env <- setupTestEnvironment [""]
-        [[importDecl "A" False "", importDecl "A" False "B"]] [modA]
-      let query     = lookupTypeName (qName "" "Bar") env
-          expResult = [(moduleName "A", Just (qName "" "Foo"))]
-      query `typeNameShouldBe` expResult
-  it "tries using no qualifier if a single import declaration is unqualified" $
-    runTest $ do
-      env <- setupTestEnvironment [""]
-        [[importDecl "A" True "", importDecl "A" False "B"]] [modA]
-      let query     = lookupTypeName (qName "A" "Bar") env
-          expResult = [(moduleName "A", Just (qName "" "Foo"))]
-      query `typeNameShouldBe` expResult
-  it ("tries using the alias names of all import declarations for "
-    ++ "unambiguous identification") $
-    runTest $ do
-      env <- setupTestEnvironment [""]
-        [ [importDecl "A" True "", importDecl "A" True "B", importDecl "A" True "C"]
-        , [importDecl "B" True "", importDecl "B" True "A"]
-        , [importDecl "C" True "", importDecl "C" True "A"]] [modA, modB, modC]
-      let query     = lookupConEntries (qName "B" "Foo") env
-          expResult = [(moduleName "A",
-                       (qName "B" "Foo", [qName "B" "Bar", qName "C" "Baz"]))]
-      query `conEntriesShouldBe` expResult
+    it "only qualifies the parts of the result that need qualification"
+      $ runTest
+      $ do
+        env <- setupTestEnvironment modA [[importDecl "C" False ""]] [modC]
+        let query     = lookupConEntries (qName "A" "Foo") env
+            expResult
+              = [ ( moduleName "A"
+                    , (qName "A" "Foo", [qName "A" "Bar", qName "" "Baz"])
+                    )
+                ]
+        query `conEntriesShouldBe` expResult
+    it ("does not return any constructors if a single one cannot be "
+        ++ "identified unambiguously")
+      $ runTest
+      $ do
+        env <- setupTestEnvironment modA [[importDecl "B" False "A"]] [modB]
+        let query     = lookupConEntries (qName "" "Foo") env
+            expResult = [(moduleName "A", (qName "" "", []))]
+        query `conEntriesShouldBe` expResult
+    it "ignores name clashes between data type and constructor names"
+      $ runTest
+      $ do
+        env <- setupTestEnvironment modA [[importDecl "D" False ""]] [modD]
+        let query     = lookupConEntries (qName "" "Bar") env
+            expResult
+              = [ ( moduleName "D"
+                    , (qName "" "Bar", [qName "" "Foo", qName "D" "Baz"])
+                    )
+                ]
+        query `conEntriesShouldBe` expResult
+  context "with multiple import declarations for the same modules" $ do
+    it ("does not consider identifiers fitting to multiple import "
+        ++ "declarations ambiguous if they all refer to the same module")
+      $ runTest
+      $ do
+        env <- setupTestEnvironment [""]
+          [[importDecl "A" False "", importDecl "A" False "B"]] [modA]
+        let query     = lookupTypeName (qName "" "Bar") env
+            expResult = [(moduleName "A", Just (qName "" "Foo"))]
+        query `typeNameShouldBe` expResult
+    it "tries using no qualifier if a single import declaration is unqualified"
+      $ runTest
+      $ do
+        env <- setupTestEnvironment [""]
+          [[importDecl "A" True "", importDecl "A" False "B"]] [modA]
+        let query     = lookupTypeName (qName "A" "Bar") env
+            expResult = [(moduleName "A", Just (qName "" "Foo"))]
+        query `typeNameShouldBe` expResult
+    it ("tries using the alias names of all import declarations for "
+        ++ "unambiguous identification")
+      $ runTest
+      $ do
+        env <- setupTestEnvironment [""]
+          [ [ importDecl "A" True ""
+              , importDecl "A" True "B"
+              , importDecl "A" True "C"
+              ]
+          , [importDecl "B" True "", importDecl "B" True "A"]
+          , [importDecl "C" True "", importDecl "C" True "A"]
+          ] [modA, modB, modC]
+        let query     = lookupConEntries (qName "B" "Foo") env
+            expResult
+              = [ ( moduleName "A"
+                    , (qName "B" "Foo", [qName "B" "Bar", qName "C" "Baz"])
+                    )
+                ]
+        query `conEntriesShouldBe` expResult

--- a/src/test/HST/EnvironmentTests.hs
+++ b/src/test/HST/EnvironmentTests.hs
@@ -21,12 +21,12 @@ import           HST.Test.Runner           ( runTest )
 -- | Parses the given modules, creates module interfaces for them and sets up
 --   an environment containing the the interface of the current module, the
 --   interfaces of the imported modules combined with the given import
---   declarations and the module interface for built-in data types.
+--   declaration lists and the module interface for built-in data types.
 setupTestEnvironment
   :: (Members '[Cancel, Report, SetExpectation, WithFrontend f] r)
-  => [String]         -- ^ The lines of the current module.
-  -> [S.ImportDecl f] -- ^ The import declarations.
-  -> [[String]]       -- ^ The lines of the imported modules.
+  => [String]           -- ^ The lines of the current module.
+  -> [[S.ImportDecl f]] -- ^ The import declaration lists.
+  -> [[String]]         -- ^ The lines of the imported modules.
   -> Sem r (Environment f)
 setupTestEnvironment currentModule importDecls importModules = do
   currentInterface <- createModuleInterface <$> parseTestModule currentModule

--- a/src/test/HST/EnvironmentTests.hs
+++ b/src/test/HST/EnvironmentTests.hs
@@ -1,0 +1,49 @@
+-- | This module contains tests for "HST.Environment".
+module HST.EnvironmentTests ( testEnvironment ) where
+
+import           Polysemy                  ( Members, Sem )
+import           Test.Hspec                ( Spec, describe, it, shouldBe )
+
+import           HST.Application           ( createModuleInterface )
+import           HST.Effect.Cancel         ( Cancel )
+import           HST.Effect.Report         ( Report )
+import           HST.Effect.SetExpectation ( SetExpectation, setExpectation )
+import           HST.Effect.WithFrontend   ( WithFrontend )
+import           HST.Environment           ( Environment(..) )
+import           HST.Environment.Prelude   ( preludeModuleInterface )
+import qualified HST.Frontend.Syntax       as S
+import           HST.Test.Parser           ( parseTestModule )
+import           HST.Test.Runner           ( runTest )
+
+-------------------------------------------------------------------------------
+-- Utility Functions                                                         --
+-------------------------------------------------------------------------------
+-- | Parses the given modules, creates module interfaces for them and sets up
+--   an environment containing the the interface of the current module, the
+--   interfaces of the imported modules combined with the given import
+--   declarations and the module interface for built-in data types.
+setupTestEnvironment
+  :: (Members '[Cancel, Report, SetExpectation, WithFrontend f] r)
+  => [String]         -- ^ The lines of the current module.
+  -> [S.ImportDecl f] -- ^ The import declarations.
+  -> [[String]]       -- ^ The lines of the imported modules.
+  -> Sem r (Environment f)
+setupTestEnvironment currentModule importDecls importModules = do
+  currentInterface <- createModuleInterface <$> parseTestModule currentModule
+  importModules' <- mapM parseTestModule importModules
+  let importInterfaces = map createModuleInterface importModules'
+  return Environment { envCurrentModule   = currentInterface
+                     , envImportedModules = zip importDecls importInterfaces
+                     , envOtherEntries    = preludeModuleInterface
+                     }
+
+-------------------------------------------------------------------------------
+-- Tests                                                                     --
+-------------------------------------------------------------------------------
+-- | Test group for "HST.Environment".
+testEnvironment :: Spec
+testEnvironment = describe "HST.Environment" $ do
+  it "" $
+    runTest $ do
+      _ <- setupTestEnvironment [] [] []
+      setExpectation (() `shouldBe` ())

--- a/src/test/HST/EnvironmentTests.hs
+++ b/src/test/HST/EnvironmentTests.hs
@@ -37,6 +37,32 @@ setupTestEnvironment currentModule importDecls importModules = do
                      , envOtherEntries    = preludeModuleInterface
                      }
 
+-- | Creates an import declaration based on the given values.
+importDecl :: String -- ^ The name of the imported module.
+           -> Bool   -- ^ @True@ if the import is qualified, @False@ otherwise.
+           -> String -- ^ The alias name of the imported module. An empty
+                     --   string signalizes an import without an alias name.
+           -> S.ImportDecl a
+importDecl mod isQual asMod = S.ImportDecl
+  { S.importSrcSpan = S.NoSrcSpan
+  , S.importModule  = moduleName mod
+  , S.importIsQual  = isQual
+  , S.importAsName  = if null asMod then Nothing else Just (moduleName asMod)
+  }
+
+-- | Creates a possibly qualified name based on the given values.
+qName :: String -- ^ The module name the name is qualified by. An empty string
+                --   signalizes an unqualified name.
+      -> String -- ^ The name without its possible qualification. It is assumed
+                --   that this is a regular identifier and not a symbol.
+      -> S.QName a
+qName "" name = S.UnQual S.NoSrcSpan (S.Ident S.NoSrcSpan name)
+qName mod name = S.Qual S.NoSrcSpan (moduleName mod) (S.Ident S.NoSrcSpan name)
+
+-- | Creates a module name based on the given name.
+moduleName :: String -> S.ModuleName a
+moduleName = S.ModuleName S.NoSrcSpan
+
 -------------------------------------------------------------------------------
 -- Tests                                                                     --
 -------------------------------------------------------------------------------

--- a/src/test/Spec.hs
+++ b/src/test/Spec.hs
@@ -7,6 +7,7 @@ import           HST.CoreAlgorithmTests  ( testCoreAlgorithm )
 import           HST.Effect.CancelTests  ( testCancelEffect )
 import           HST.Effect.FreshTests   ( testFreshEffect )
 import           HST.Effect.ReportTests  ( testReportEffect )
+import           HST.EnvironmentTests    ( testEnvironment )
 import           HST.Util.FreeVarsTests  ( testFreeVars )
 import           HST.Util.SelectorsTests ( testSelectors )
 import           HST.Util.SubstTests     ( testSubst )
@@ -16,6 +17,7 @@ main = hspec $ do
   testApplication
   testCancelEffect
   testCoreAlgorithm
+  testEnvironment
   testFreshEffect
   testFreeVars
   testReportEffect


### PR DESCRIPTION
### Issue
Closes #12.

### Description of the Change
This pull request will add support for qualified identifiers in the following way:
- The lookup functions for the environment have been expanded so that they always search with the unqualified identifier, but only in the interfaces of the modules that the full identifier could refer to (with respect to the import specifications).
- The identifiers returned by the lookup are qualified correctly. This is done by looking up of all allowed variants (unqualified or qualified or just one of those) of all identifiers found and then checking for ambiguity. If there is a correct and unambiguous identifier, it is returned (unqualified identifiers are prioritized). If there isn't, `Nothing` is returned and propagated. You can see some examples for this in the _Verification Process_ section.

### Alternate Designs
The qualification and ambiguity check for lookup results is done together with the lookups, but it could alternatively be done when initializing the environment. This would make the lookups more efficient, especially when looking up the same identifier twice. As we use strict maps however, this change would mean that these qualifications and ambiguity checks would be evaluated for all entries in the environment with the initialization, which would be less efficient in most cases. I might be wrong with these efficiency assumptions, however.

### Verification Process
I have done some manual tests, for example with these modules:
```haskell
module A where
data Foo = Bar | Baz
```
```haskell
module B where
data Foo2 = Bar | Baz2
```
`A` and `B` stay the same in the following tests:
#### Test 1
Input:
```haskell
module C1 where
import A
import B
test1 Baz = 5
```
Here, `Baz` is unambigous, as it only occurs in `A`, but `Bar` occurs in `B` as well and therefore is ambiguous. Therefore, the pattern must be completed with `A.Bar`.
Output:
```haskell
module C1 where
import A
import B
test1 a0
  = case a0 of
        Baz -> 5
        A.Bar -> undefined
```
#### Test 2
Input:
```haskell
module C2 where
import A
import B as A
test2 Baz = 5
```
Once again, `Baz` is unambiguous, but it's now impossible to correctly qualify `Bar`, as both the `Bar` coming from `A` and the one coming from `B` would be identified with `Bar` and `A.Bar`. Therefore, an error must be reported.
Output:
```
Error: Constructor entries for the data type `Foo` could not be returned, because at least one of them cannot be identified unambiguously.
```
#### Test 3
Input:
```haskell
module C3 where
import A
import qualified B as A
test3 A.Baz = 5
```
Here, `A.Baz` is still unambiguous (just `Baz` would be unambiguous as well), but things have changed with `Bar`: While `A.Bar` would be ambiguous, just `Bar` is not, as it can no longer refer to module `B`. Therefore, the pattern must be completed with `Bar`.
Output:
```haskell
module C3 where
import A
import qualified B as A
test3 a0
  = case a0 of
        A.Baz -> 5
        Bar -> undefined
```
#### Test 4
Input:
```haskell
module C4 where
import A
import B
test4 Bar = 5
```
Lastly, `Bar` used in this code is directly ambiguous, so we report a helpul error message.
Output:
```
Error: Ambiguous data constructor `Bar` could refer to one of the following modules: A, B
C.hs:4:7-4:10:
4 | test4 Bar = 5
          ^^^
```
### Additional Notes
There might be some places left in the code where `QName`s are compared and possible qualifications have not been taken into consideration. If you know of such places, please let me know.